### PR TITLE
stylelint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+root = true
+
+[*]
+end_of_line = LF
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.html]
+indent_size = 4
+
+[*.json]
+indent_style = tab
+indent_size = 4
+insert_final_newline = false
+
+[package.json]
+indent_style = space
+indent_size = 2
+
+[.platoignore]
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab
+
+[.yml]
+indent_style = space
+indent_size = 2

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test/coverage-hooks.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    "extends": [
+        "./node_modules/fs-default-project-config/resources/.eslintrc-standards.js",
+        "./node_modules/fs-default-project-config/resources/.eslint-nodejs-commonjs.js",
+        "./node_modules/fs-default-project-config/resources/.eslintrc-files.js"
+    ]
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+npm-debug.log*

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
     ],
     "rules": Object.assign(
         {
-            "csstree/validator": {"ignore": ["background", "background-color"]}, // gets upset by sass rgba() function
+            'csstree/validator': {ignore: ['background', 'background-color', 'box-shadow']}, // gets upset by sass rgba() function
             "plugin/declaration-block-no-ignored-properties": true,
             "scale-unlimited/declaration-strict-value": [["/color/", "z-index", "font-size", "line-height"], { ignoreKeywords: ["currentColor", "transparent", "inherit"] }],
             "plugin/selector-bem-pattern": {

--- a/index.js
+++ b/index.js
@@ -1,0 +1,32 @@
+'use strict'
+
+// See https://stylelint.io/user-guide/example-config/
+module.exports = {
+    "syntax": "scss",
+    "plugins": [
+      "stylelint-csstree-validator",
+      "stylelint-declaration-block-no-ignored-properties",
+      "stylelint-declaration-strict-value",
+      "stylelint-order",
+      "stylelint-selector-bem-pattern"
+      // "stylelint-scss" // TODO: review & configure this
+    ],
+    "rules": Object.assign(
+        {
+            "csstree/validator": {"ignore": ["background", "background-color"]}, // gets upset by sass rgba() function
+            "plugin/declaration-block-no-ignored-properties": true,
+            "scale-unlimited/declaration-strict-value": [["/color/", "z-index", "font-size", "line-height"], { ignoreKeywords: ["currentColor", "transparent", "inherit"] }],
+            "plugin/selector-bem-pattern": {
+                "componentName": "/^[-_a-z0-9]+$/",
+                "componentSelectors": {
+                    "initial": "^\\.{componentName}(?:-[a-z]+)?$",
+                    "combined": "^\\.combined-{componentName}-[a-z]+$"
+                }
+            }
+        },
+        require('./rules/stylelint-order.js'),
+        require('./rules/limit-language-features.js'),
+        require('./rules/possible-errors.js'),
+        require('./rules/stylistic-issues.js')
+    )
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "stylelint-config-foxsports",
+  "version": "0.0.1",
+  "description": "sharable stylelint config",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@bitbucket.foxsports.com.au:7999/~sean.carey/stylelint-config-foxsports.git"
+  },
+  "keywords": [
+    "stylelint"
+  ],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "eslint": "^4.9.0",
+    "eslint-plugin-filenames": "^1.1.0",
+    "eslint-plugin-import": "^2.8.0",
+    "fs-default-project-config": "^6.1.2"
+  },
+  "peerDependencies": {
+    "stylelint": "^8.2.0"
+  },
+  "dependencies": {
+    "stylelint-csstree-validator": "^1.2.0",
+    "stylelint-declaration-block-no-ignored-properties": "^1.0.1",
+    "stylelint-declaration-strict-value": "^1.0.4",
+    "stylelint-order": "^0.7.0",
+    "stylelint-selector-bem-pattern": "^2.0.0"
+  }
+}

--- a/rules/limit-language-features.js
+++ b/rules/limit-language-features.js
@@ -1,0 +1,84 @@
+'use strict'
+
+module.exports = {
+    // Color
+    'color-named': "never", // Require (where possible) or disallow named colors.
+    'color-no-hex': null, // Disallow hex colors.
+
+    // Function
+    'function-blacklist': null, // Specify a blacklist of disallowed functions.
+    'function-url-no-scheme-relative': true, // Disallow scheme-relative urls.
+    'function-url-scheme-blacklist': ["ftp", "/^http/"], // Specify a blacklist of disallowed url schemes.
+    'function-url-scheme-whitelist': null, // Specify a whitelist of allowed url schemes.
+    'function-whitelist': null, // Specify a whitelist of allowed functions.
+
+    // Number
+    'number-max-precision': 2, // Limit the number of decimal places allowed in numbers.
+
+    // Time
+    'time-min-milliseconds': 100, // Specify the minimum number of milliseconds for time values.
+
+    // Unit
+    'unit-blacklist': null, // Specify a blacklist of disallowed units.
+    'unit-whitelist': null, // Specify a whitelist of allowed units.
+
+    // Value
+    'value-no-vendor-prefix': true, // Disallow vendor prefixes for values.
+
+    // Custom property
+    'custom-property-pattern': "fs-.+", // Specify a pattern for custom properties.
+
+    // Property
+    'property-blacklist': null, // Specify a blacklist of disallowed properties.
+    'property-no-vendor-prefix': true, // Disallow vendor prefixes for properties.
+    'property-whitelist': null, // Specify a whitelist of allowed properties.
+
+    // Declaration
+    'declaration-no-important': true, // Disallow !important within declarations.
+    'declaration-property-unit-blacklist': null, // Specify a blacklist of disallowed property and unit pairs within declarations.
+    'declaration-property-unit-whitelist': null, // Specify a whitelist of allowed property and unit pairs within declarations.
+    'declaration-property-value-blacklist': null, // Specify a blacklist of disallowed property and value pairs within declarations.
+    'declaration-property-value-whitelist': null, // Specify a whitelist of allowed property and value pairs within declarations.
+
+    // Declaration block
+    'declaration-block-single-line-max-declarations': null, // Limit the number of declaration within single line declaration blocks.
+
+    // Selector
+    'selector-attribute-operator-blacklist': null, // Specify a blacklist of disallowed attribute operators.
+    'selector-attribute-operator-whitelist': null, // Specify a whitelist of allowed attribute operators.
+    'selector-class-pattern': null, // Specify a pattern for class selectors.
+    'selector-id-pattern': null, // Specify a pattern for id selectors.
+    'selector-max-attribute': 2, // Limit the number of attribute selectors in a selector.
+    'selector-max-class': 3, // Limit the number of classes in a selector.
+    'selector-max-combinators': 2, // Limit the number of combinators in a selector.
+    'selector-max-compound-selectors': 3, // Limit the number of compound selectors in a selector.
+    'selector-max-empty-lines': 0, // Limit the number of adjacent empty lines within selectors.
+    'selector-max-id': 1, // Limit the number of id selectors in a selector.
+    'selector-max-specificity': ["0,4,2", {ignoreSelectors: ['.fsui-normalise', '.fiso-widget']}], // Limit the specificity of selectors.
+    'selector-max-type': 2, // Limit the number of type in a selector.
+    'selector-max-universal': 1, // Limit the number of universal selectors in a selector.
+    'selector-nested-pattern': null, // Specify a pattern for the selectors of rules nested within rules.
+    'selector-no-qualifying-type': [true, { ignore: ["attribute"] }], // Disallow qualifying a selector by type.
+    'selector-no-vendor-prefix': true, // Disallow vendor prefixes for selectors.
+    'selector-pseudo-class-blacklist': null, // Specify a blacklist of disallowed pseudo-class selectors.
+    'selector-pseudo-class-whitelist': null, // Specify a whitelist of allowed pseudo-class selectors.
+
+    // Media feature
+    'media-feature-name-blacklist': null, // Specify a blacklist of disallowed media feature names.
+    'media-feature-name-no-vendor-prefix': true, // Disallow vendor prefixes for media feature names.
+    'media-feature-name-whitelist': null, // Specify a whitelist of allowed media feature names.
+
+    // Custom media
+    'custom-media-pattern': "fs-.+", // Specify a pattern for custom media query names.
+
+    // At-rule
+    'at-rule-blacklist': null, // Specify a blacklist of disallowed at-rules.
+    'at-rule-no-vendor-prefix': true, // Disallow vendor prefixes for at-rules.
+    'at-rule-whitelist': null, // Specify a whitelist of allowed at-rules.
+
+    // Comment
+    'comment-word-blacklist': ["/^TODO/", { "severity": "warning" }], // Specify a blacklist of disallowed words within comments.
+
+    // General / Sheet
+    'max-nesting-depth': 3, // Limit the depth of nesting.
+}

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -1,0 +1,58 @@
+'use strict'
+
+module.exports = {
+    // Color
+    'color-no-invalid-hex': true, // Disallow invalid hex colors.
+
+    // Font family
+    'font-family-no-duplicate-names': true, // Disallow duplicate font family names.
+
+    // Function
+    'function-calc-no-unspaced-operator': true, // Disallow an unspaced operator within calc functions.
+    'function-linear-gradient-no-nonstandard-direction': true, // Disallow direction values in linear-gradient() calls that are not valid according to the standard syntax.
+
+    // String
+    'string-no-newline': true, // Disallow (unescaped) newlines in strings.
+
+    // Unit
+    'unit-no-unknown': true, // Disallow unknown units.
+
+    // Shorthand property
+    'shorthand-property-no-redundant-values': true, // Disallow redundant values in shorthand properties.
+
+    // Property
+    'property-no-unknown': true, // Disallow unknown properties.
+
+    // Keyframe declaration
+    'keyframe-declaration-no-important': true, // Disallow !important within keyframe declarations.
+
+    // Declaration block
+    'declaration-block-no-duplicate-properties': true, // Disallow duplicate properties within declaration blocks.
+    'declaration-block-no-redundant-longhand-properties': true, // Disallow longhand properties that can be combined into one shorthand property.
+    'declaration-block-no-shorthand-property-overrides': true, // Disallow shorthand properties that override related longhand properties within declaration blocks.
+
+    // Block
+    'block-no-empty': true, // Disallow empty blocks.
+
+    // Selector
+    'selector-pseudo-class-no-unknown': true, // Disallow unknown pseudo-class selectors.
+    'selector-pseudo-element-no-unknown': true, // Disallow unknown pseudo-element selectors.
+    'selector-type-no-unknown': true, // Disallow unknown type selectors.
+
+    // Media feature
+    'media-feature-name-no-unknown': true, // Disallow unknown media feature names.
+
+    // At-rule
+    'at-rule-no-unknown': [true, {ignoreAtRules: ["/^include/", "/^each/", "/^function/", "/^return/", "/^for/", "/^mixin/", "/^function/", "/^return/"]}], // Disallow unknown at-rules.
+
+    // Comment
+    'comment-no-empty': true, // Disallow empty comments.
+
+    // General / Sheet
+    'no-descending-specificity': true, // Disallow selectors of lower specificity from coming after overriding selectors of higher specificity.
+    'no-duplicate-selectors': true, // Disallow duplicate selectors.
+    'no-empty-source': true, // Disallow empty sources.
+    'no-extra-semicolons': true, // Disallow extra semicolons.
+    'no-invalid-double-slash-comments': true, // Disallow double-slash comments (//...) which are not supported by CSS.
+    'no-unknown-animations': null // Disallow unknown animations.
+}

--- a/rules/stylelint-order.js
+++ b/rules/stylelint-order.js
@@ -1,0 +1,264 @@
+module.exports = {
+    // ...
+    "order/order": [
+        "custom-properties",
+        {
+            type: 'at-rule',
+            name: 'include'
+        },
+        "declarations",
+        {
+            type: 'rule',
+            selector: / &/
+        },
+        {
+            type: 'rule',
+            selector: /^&/
+        },
+        {
+            type: 'at-rule',
+            name: 'media'
+        },
+        "rules"
+    ],
+    "order/properties-order": [ // Concentric CSS order taken from https://github.com/brandon-rhodes/Concentric-CSS
+          /* box-sizing */
+          /* [content-box|border-box|inherit|initial|unset]*/
+          'box-sizing',
+
+          /* position */
+          'display',
+          'position',
+          'top',
+          'right',
+          'bottom',
+          'left',
+
+          'float',
+          'clear',
+
+          /* align-content */
+          'align-content',
+          'align-items',
+          'align-self',
+
+          /* flex  */
+          'flex',
+          'flex-basis',
+          'flex-direction',
+          'flex-flow',
+          'flex-grow',
+          'flex-shrink',
+          'flex-wrap',
+          'justify-content',
+
+          /* order */
+          'order',
+
+          /* columns */
+          'columns',
+          'column-gap',
+          'column-fill',
+          'column-rule',
+          'column-rule-width',
+          'column-rule-style',
+          'column-rule-color',
+          'column-span',
+          'column-count',
+          'column-width',
+
+          /* transform */
+          'backface-visibility',
+          'perspective',
+          'perspective-origin',
+          'transform',
+          'transform-origin',
+          'transform-style',
+
+          /* tranistions */
+          'transition',
+          'transition-delay',
+          'transition-duration',
+          'transition-property',
+          'transition-timing-function',
+
+          /* visibility */
+          'visibility',
+          'opacity',
+          'z-index',
+
+          /* margin */
+          'margin',
+          'margin-top',
+          'margin-right',
+          'margin-bottom',
+          'margin-left',
+
+          /* outline */
+          'outline',
+          'outline-offset',
+          'outline-width',
+          'outline-style',
+          'outline-color',
+
+          /* border */
+          'border',
+          'border-top',
+          'border-right',
+          'border-bottom',
+          'border-left',
+          'border-width',
+          'border-top-width',
+          'border-right-width',
+          'border-bottom-width',
+          'border-left-width',
+
+          /* border-style */
+          'border-style',
+          'border-top-style',
+          'border-right-style',
+          'border-bottom-style',
+          'border-left-style',
+
+          /* border-radius */
+          'border-radius',
+          'border-top-left-radius',
+          'border-top-right-radius',
+          'border-bottom-left-radius',
+          'border-bottom-right-radius',
+
+          /* border-color */
+          'border-color',
+          'border-top-color',
+          'border-right-color',
+          'border-bottom-color',
+          'border-left-color',
+
+          /* border-image */
+          'border-image',
+          'border-image-source',
+          'border-image-width',
+          'border-image-outset',
+          'border-image-repeat',
+          'border-image-slice',
+
+          /* box-shadow */
+          'box-shadow',
+
+          /* background */
+          'background',
+          'background-attachment',
+          'background-clip',
+          'background-color',
+          'background-image',
+          'background-origin',
+          'background-position',
+          'background-repeat',
+          'background-size',
+
+          /* cursor */
+          'cursor',
+
+          /* padding */
+          'padding',
+          'padding-top',
+          'padding-right',
+          'padding-bottom',
+          'padding-left',
+
+          /* width */
+          'width',
+          'min-width',
+          'max-width',
+
+          /* height */
+          'height',
+          'min-height',
+          'max-height',
+
+          /* overflow */
+          'overflow',
+          'overflow-x',
+          'overflow-y',
+          'resize',
+
+          /* list-style */
+          'list-style',
+          'list-style-type',
+          'list-style-position',
+          'list-style-image',
+          'caption-side',
+
+          /* tables */
+          'table-layout',
+          'border-collapse',
+          'border-spacing',
+          'empty-cells',
+
+          /* animation */
+          /* animation-[[name] [duration] [timing-function] [delay] [iteration-count] [direction] [fill-mode] [play-state]]*/
+          'animation',
+          'animation-name',
+          'animation-duration',
+          'animation-timing-function',
+          'animation-delay',
+          'animation-iteration-count',
+          'animation-direction',
+          'animation-fill-mode',
+          'animation-play-state',
+
+          /* vertical-aligment */
+          'vertical-align',
+
+          /* text-alignment & decoration */
+          'direction',
+          'tab-size',
+          'text-align',
+          'text-align-last',
+          'text-justify',
+          'text-indent',
+          'text-transform',
+          'text-decoration',
+          'text-decoration-color',
+          'text-decoration-line',
+          'text-decoration-style',
+          'text-rendering',
+          'text-shadow',
+          'text-overflow',
+
+          /* text-spacing */
+          'line-height',
+          'word-spacing',
+          'letter-spacing',
+          'white-space',
+          'word-break',
+          'word-wrap',
+          'color',
+
+          /* font */
+          'font',
+          'font-family',
+          'font-size',
+          'font-size-adjust',
+          'font-stretch',
+          'font-weight',
+          'font-smoothing',
+          'osx-font-smoothing',
+          'font-variant',
+          'font-style',
+
+          /* content */
+          'content',
+          'quotes',
+
+          /* counters */
+          'counter-reset',
+          'counter-increment',
+
+          /* breaks */
+          'page-break-before',
+          'page-break-after',
+          'page-break-inside'
+    ],
+    "order/properties-alphabetical-order": null
+}

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -1,0 +1,136 @@
+'use strict'
+
+module.exports = {
+    // Color
+    'color-hex-case': 'lower', // Specify lowercase or uppercase for hex colors (Autofixable).
+    'color-hex-length': 'short', // Specify short or long notation for hex colors (Autofixable).
+
+    // Font family
+    'font-family-name-quotes': 'always-where-recommended', // Specify whether or not quotation marks should be used around font family names.
+
+    // Font weight
+    'font-weight-notation': 'named-where-possible', // Require numeric or named (where possible) font-weight values.
+
+    // Function
+    'function-comma-newline-after': null, // Require a newline or disallow whitespace after the commas of functions.
+    'function-comma-newline-before': 'never-multi-line', // Require a newline or disallow whitespace before the commas of functions.
+    'function-comma-space-after': 'always', // Require a single space or disallow whitespace after the commas of functions.
+    'function-comma-space-before': 'never', // Require a single space or disallow whitespace before the commas of functions.
+    'function-max-empty-lines': 0, // Limit the number of adjacent empty lines within functions.
+    'function-name-case': 'lower', // Specify lowercase or uppercase for function names.
+    'function-parentheses-newline-inside': null, // Require a newline or disallow whitespace on the inside of the parentheses of functions.
+    'function-parentheses-space-inside': 'never', // Require a single space or disallow whitespace on the inside of the parentheses of functions.
+    'function-url-quotes': 'always', // Require or disallow quotes for urls.
+    'function-whitespace-after': 'always', // Require or disallow whitespace after functions.
+
+    // Number
+    'number-leading-zero': 'never', // Require or disallow a leading zero for fractional numbers less than 1.
+    'number-no-trailing-zeros': true, // Disallow trailing zeros in numbers.
+
+    // String
+    'string-quotes': 'single', // Specify single or double quotes around strings.
+
+    // Length
+    'length-zero-no-unit': true, // Disallow units for zero lengths.
+
+    // Unit
+    'unit-case': 'lower', // Specify lowercase or uppercase for units.
+
+    // Value
+    'value-keyword-case': 'lower', // Specify lowercase or uppercase for keywords values.
+
+    // Value list
+    'value-list-comma-newline-after': null, // Require a newline or disallow whitespace after the commas of value lists.
+    'value-list-comma-newline-before': 'never-multi-line', // Require a newline or disallow whitespace before the commas of value lists.
+    'value-list-comma-space-after': 'always', // Require a single space or disallow whitespace after the commas of value lists.
+    'value-list-comma-space-before': 'never', // Require a single space or disallow whitespace before the commas of value lists.
+    'value-list-max-empty-lines': 0, // Limit the number of adjacent empty lines within value lists.
+
+    // Custom property
+    'custom-property-empty-line-before': ["always", { except: ["after-comment", "after-custom-property", "first-nested"] }], // Require or disallow an empty line before custom properties (Autofixable).
+
+    // Property
+    'property-case': 'lower', // Specify lowercase or uppercase for properties.
+
+    // Declaration
+    'declaration-bang-space-after': "never", // Require a single space or disallow whitespace after the bang of declarations.
+    'declaration-bang-space-before': "always", // Require a single space or disallow whitespace before the bang of declarations.
+    'declaration-colon-newline-after': null, // Require a newline or disallow whitespace after the colon of declarations.
+    'declaration-colon-space-after': "always", // Require a single space or disallow whitespace after the colon of declarations.
+    'declaration-colon-space-before': "never", // Require a single space or disallow whitespace before the colon of declarations.
+    'declaration-empty-line-before': ["never", {ignore: ["after-comment", "after-declaration"]}], // Require or disallow an empty line before declarations (Autofixable).
+
+    // Declaration block
+    'declaration-block-semicolon-newline-after': "always", // Require a newline or disallow whitespace after the semicolons of declaration blocks.
+    'declaration-block-semicolon-newline-before': null, // Require a newline or disallow whitespace before the semicolons of declaration blocks.
+    'declaration-block-semicolon-space-after': null, // Require a single space or disallow whitespace after the semicolons of declaration blocks.
+    'declaration-block-semicolon-space-before': "never", // Require a single space or disallow whitespace before the semicolons of declaration blocks.
+    'declaration-block-trailing-semicolon': "always", // Require or disallow a trailing semicolon within declaration blocks.
+
+    // Block
+    'block-closing-brace-empty-line-before': "never", // Require or disallow an empty line before the closing brace of blocks.
+    'block-closing-brace-newline-after': "always", // Require a newline or disallow whitespace after the closing brace of blocks.
+    'block-closing-brace-newline-before': "always-multi-line", // Require a newline or disallow whitespace before the closing brace of blocks.
+    'block-closing-brace-space-after': null, // Require a single space or disallow whitespace after the closing brace of blocks.
+    'block-closing-brace-space-before': 'always-single-line', // Require a single space or disallow whitespace before the closing brace of blocks.
+    'block-opening-brace-newline-after': "always-multi-line", // Require a newline after the opening brace of blocks.
+    'block-opening-brace-newline-before': null, // Require a newline or disallow whitespace before the opening brace of blocks.
+    'block-opening-brace-space-after': "always-single-line", // Require a single space or disallow whitespace after the opening brace of blocks.
+    'block-opening-brace-space-before': "always", // Require a single space or disallow whitespace before the opening brace of blocks.
+
+    // Selector
+    'selector-attribute-brackets-space-inside': "never", // Require a single space or disallow whitespace on the inside of the brackets within attribute selectors.
+    'selector-attribute-operator-space-after': "never", // Require a single space or disallow whitespace after operators within attribute selectors.
+    'selector-attribute-operator-space-before': "never", // Require a single space or disallow whitespace before operators within attribute selectors.
+    'selector-attribute-quotes': "always", // Require or disallow quotes for attribute values.
+    'selector-combinator-space-after': "always", // Require a single space or disallow whitespace after the combinators of selectors.
+    'selector-combinator-space-before': "always", // Require a single space or disallow whitespace before the combinators of selectors.
+    'selector-descendant-combinator-no-non-space': true, // Disallow non-space characters for descendant combinators of selectors.
+    'selector-pseudo-class-case': "lower", // Specify lowercase or uppercase for pseudo-class selectors.
+    'selector-pseudo-class-parentheses-space-inside': "never", // Require a single space or disallow whitespace on the inside of the parentheses within pseudo-class selectors.
+    'selector-pseudo-element-case': "lower", // Specify lowercase or uppercase for pseudo-element selectors.
+    'selector-pseudo-element-colon-notation': "double", // Specify single or double colon notation for applicable pseudo-elements.
+    'selector-type-case': "lower", // Specify lowercase or uppercase for type selector.
+
+    // Selector list
+    'selector-list-comma-newline-after': "always", // Require a newline or disallow whitespace after the commas of selector lists.
+    'selector-list-comma-newline-before': null, // Require a newline or disallow whitespace before the commas of selector lists.
+    'selector-list-comma-space-after': null, // Require a single space or disallow whitespace after the commas of selector lists.
+    'selector-list-comma-space-before': null, // Require a single space or disallow whitespace before the commas of selector lists.
+
+    // Rule
+    'rule-empty-line-before': ["always", {except: ["first-nested"]}], // Require or disallow an empty line before rules (Autofixable).
+
+    // Media feature
+    'media-feature-colon-space-after': "always", // Require a single space or disallow whitespace after the colon in media features.
+    'media-feature-colon-space-before': "never", // Require a single space or disallow whitespace before the colon in media features.
+    'media-feature-name-case': "lower", // Specify lowercase or uppercase for media feature names.
+    'media-feature-parentheses-space-inside': "never", // Require a single space or disallow whitespace on the inside of the parentheses within media features.
+    'media-feature-range-operator-space-after': "always", // Require a single space or disallow whitespace after the range operator in media features.
+    'media-feature-range-operator-space-before': "always", // Require a single space or disallow whitespace before the range operator in media features.
+
+    // Media query list
+    'media-query-list-comma-newline-after': "always-multi-line", // Require a newline or disallow whitespace after the commas of media query lists.
+    'media-query-list-comma-newline-before': "never-multi-line", // Require a newline or disallow whitespace before the commas of media query lists.
+    'media-query-list-comma-space-after': "always", // Require a single space or disallow whitespace after the commas of media query lists.
+    'media-query-list-comma-space-before': "never", // Require a single space or disallow whitespace before the commas of media query lists.
+
+    // At-rule
+    'at-rule-empty-line-before': ["always", {except: ["blockless-after-same-name-blockless", "blockless-after-blockless", "first-nested"], ignore: ["after-comment"], ignoreAtRules: ["import"]}], // Require or disallow an empty line before at-rules (Autofixable).
+    'at-rule-name-case': "lower", // Specify lowercase or uppercase for at-rules names (Autofixable).
+    'at-rule-name-newline-after': null, // Require a newline after at-rule names.
+    'at-rule-name-space-after': "always", // Require a single space after at-rule names.
+    'at-rule-semicolon-newline-after': "always", // Require a newline after the semicolon of at-rules.
+    'at-rule-semicolon-space-before': "never", // Require a single space or disallow whitespace before the semicolons of at rules.
+
+    // Comment
+    'comment-empty-line-before': ["never", { except: ["first-nested"], ignore: ["after-comment", "stylelint-commands"] }], // Require or disallow an empty line before comments (Autofixable).
+    'comment-whitespace-inside': "always", // Require or disallow whitespace on the inside of comment markers.
+
+    // General / Sheet
+    'indentation': [4], // Specify indentation (Autofixable).
+    'max-empty-lines': [1, { ignore: ["comments"] }], // Limit the number of adjacent empty lines.
+    'max-line-length': null, // Limit the length of a line.
+    'no-eol-whitespace': true, // Disallow end-of-line whitespace.
+    'no-missing-end-of-source-newline': true, // Disallow missing end-of-source newlines (Autofixable).
+}


### PR DESCRIPTION
Ported fox sports's existing linting rules from `scss-lint` to stylelint to facilitate usage in [styled-components](https://www.styled-components.com/docs/tooling#stylelint)