### PR TITLE
WEB-1417-updating styelint to 14.0.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/configure
 module.exports = {
-    "customSyntax": "postcss-scss",
+    "customSyntax": "@stylelint/postcss-css-in-js",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -6,16 +6,16 @@
 // So if we want our explicit definitions to extend the default, we do this:
 const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
-// See https://stylelint.io/user-guide/example-config/
+// See https://stylelint.io/user-guide/configure
 module.exports = {
-    "customSyntax": "sass",
+    "customSyntax": "scss",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",
       "stylelint-declaration-strict-value",
       "stylelint-order",
-      "stylelint-selector-bem-pattern"
-      // "stylelint-scss" // TODO: review & configure this
+      "stylelint-selector-bem-pattern",
+      "stylelint-scss", // TODO: review & configure this
     ],
     "rules": Object.assign(
         {

--- a/index.js
+++ b/index.js
@@ -52,12 +52,5 @@ module.exports = {
     "reportInvalidScopeDisables": true,
     "ignoreDisables": false,
     "ignoreFiles": [],
-    "overrides": [
-        {
-            "files": ["docs/assets/*.css"],
-            "rules": {
-                'color-no-hex': false, // Disallow hex colors.
-            }
-        }
-    ]
+    "overrides": []
 }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/configure
 module.exports = {
-    "customSyntax": "postcss-styled",
+    "customSyntax": "postcss-scss",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/configure
 module.exports = {
-    "customSyntax": "scss",
+    "customSyntax": "postcss-scss",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/configure
 module.exports = {
+    "customSyntax": "postcss-styled",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ module.exports = {
       "stylelint-declaration-block-no-ignored-properties",
       "stylelint-declaration-strict-value",
       "stylelint-order",
-      "stylelint-selector-bem-pattern",
-      "stylelint-scss", // TODO: review & configure this
+      "stylelint-selector-bem-pattern"
+    //   "stylelint-scss", // TODO: review & configure this
     ],
     "rules": Object.assign(
         {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = {
         require('./rules/possible-errors.js'),
         require('./rules/stylistic-issues.js')
     ),
-    "reportDescriptionlessDisables": true,
+    "reportDescriptionlessDisables": false,
     "reportNeedlessDisables": true,
     "reportInvalidScopeDisables": true,
     "ignoreDisables": false,

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/configure
 module.exports = {
-    "customSyntax": "postcss-styled",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/configure
 module.exports = {
-    "customSyntax": "@stylelint/postcss-css-in-js",
+    "customSyntax": "postcss-scss",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/configure
 module.exports = {
-   // "customSyntax": "scss",
+    "customSyntax": "postcss-scss",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/example-config/
 module.exports = {
-    "customSyntax": "xyz",
+    "customSyntax": "postcss-scss",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/example-config/
 module.exports = {
-    "customSyntax": "scss",
+    "customSyntax": "sass",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/example-config/
 module.exports = {
-    "customSyntax": "scss",
+    "customSyntax": "xyz",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/configure
 module.exports = {
-    "customSyntax": "postcss-scss",
+    "customSyntax": "scss",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/configure
 module.exports = {
-    "customSyntax": "postcss-css-in-js",
+    "customSyntax": "@stylelint/postcss-css-in-js",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/example-config/
 module.exports = {
-    "customSyntax": "postcss-scss",
+    "customSyntax": "scss",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/example-config/
 module.exports = {
-    "syntax": "scss",
+    "customSyntax": "scss",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",
@@ -46,5 +46,18 @@ module.exports = {
         require('./rules/limit-language-features.js'),
         require('./rules/possible-errors.js'),
         require('./rules/stylistic-issues.js')
-    )
+    ),
+    "reportDescriptionlessDisables": true,
+    "reportNeedlessDisables": true,
+    "reportInvalidScopeDisables": true,
+    "ignoreDisables": false,
+    "ignoreFiles": [],
+    "overrides": [
+        {
+            "files": ["docs/assets/*.css"],
+            "rules": {
+                'color-no-hex': false, // Disallow hex colors.
+            }
+        }
+    ]
 }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/configure
 module.exports = {
-    "customSyntax": "scss",
+   // "customSyntax": "scss",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/configure
 module.exports = {
-    "customSyntax": "@stylelint/postcss-css-in-js",
+    "customSyntax": "postcss-css-in-js",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const strictValueDefaults = ['inherit', 'initial', 'unset'];
 
 // See https://stylelint.io/user-guide/configure
 module.exports = {
-    "customSyntax": "postcss-scss",
+    "customSyntax": "postcss-styled",
     "plugins": [
       "stylelint-csstree-validator",
       "stylelint-declaration-block-no-ignored-properties",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2580,11 +2580,6 @@
         }
       }
     },
-    "postcss-styled": {
-      "version": "0.34.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-styled/-/postcss-styled-0.34.0.tgz",
-      "integrity": "sha1-B9R7yxNwcol4KqBYYF/Z/q+EOR0="
-    },
     "postcss-value-parser": {
       "version": "3.3.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2512,6 +2512,11 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha1-u0wpiUFxqUvFyZa5owMX70Aq2qE="
     },
+    "postcss-scss": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-scss/-/postcss-scss-4.0.2.tgz",
+      "integrity": "sha1-Od3MCrMvFV1asyjukTU9Z6UtU3s="
+    },
     "postcss-selector-parser": {
       "version": "6.0.6",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2833,6 +2833,11 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha1-u0wpiUFxqUvFyZa5owMX70Aq2qE="
     },
+    "postcss-scss": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.2.tgz",
+      "integrity": "sha512-xfdkU128CkKKKVAwkyt0M8OdnelJ3MRcIRAPPQkRpoPeuzWY3RIeg7piRCpZ79MK7Q16diLXMMAD9dN5mauPlQ=="
+    },
     "postcss-selector-parser": {
       "version": "6.0.6",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2575,6 +2575,11 @@
         }
       }
     },
+    "postcss-styled": {
+      "version": "0.34.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-styled/-/postcss-styled-0.34.0.tgz",
+      "integrity": "sha1-B9R7yxNwcol4KqBYYF/Z/q+EOR0="
+    },
     "postcss-value-parser": {
       "version": "3.3.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,266 +5,72 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha1-DfyAMJvuyEEeZecGRhxAiwu5tDE=",
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.16.0"
       }
     },
-    "@babel/core": {
-      "version": "7.4.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@babel/core/-/core-7.4.4.tgz",
-      "integrity": "sha1-hAVXULBfzVD5kVqCa0T6NHqCUlA=",
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
-        "@babel/helpers": "^7.4.4",
-        "@babel/parser": "^7.4.4",
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4",
-        "convert-source-map": "^1.1.0",
-        "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.11",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
-    "@babel/generator": {
-      "version": "7.4.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@babel/generator/-/generator-7.4.4.tgz",
-      "integrity": "sha1-F0ohXrhD/DksftyqvqqHPebo8EE=",
-      "requires": {
-        "@babel/types": "^7.4.4",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-      "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
-      "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-      "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
-      "requires": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.4.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-      "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
-      "requires": {
-        "@babel/types": "^7.4.4"
-      }
-    },
-    "@babel/helpers": {
-      "version": "7.4.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@babel/helpers/-/helpers-7.4.4.tgz",
-      "integrity": "sha1-hosO9Zwd1OeHRFYtXOG1nIny8qU=",
-      "requires": {
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
-      }
+    "@babel/helper-validator-identifier": {
+      "version": "7.15.7",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha1-Ig35k7/pBKSmsCq08zhaXr9uI4k="
     },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha1-bOsysspLj182H7f9gh4/3fShclo=",
       "requires": {
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       },
       "dependencies": {
         "js-tokens": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/js-tokens/-/js-tokens-4.0.0.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/js-tokens/-/js-tokens-4.0.0.tgz",
           "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
         }
       }
     },
-    "@babel/parser": {
-      "version": "7.4.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@babel/parser/-/parser-7.4.4.tgz",
-      "integrity": "sha1-WXcSlDG4/jNHFzDSVc6GVK4SULY="
-    },
-    "@babel/template": {
-      "version": "7.4.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@babel/template/-/template-7.4.4.tgz",
-      "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.4",
-        "@babel/types": "^7.4.4"
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.4.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@babel/traverse/-/traverse-7.4.4.tgz",
-      "integrity": "sha1-B3bwOPbXg2GGC2gjiH1POTcTP+g=",
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.4.4",
-        "@babel/types": "^7.4.4",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
-        }
-      }
-    },
-    "@babel/types": {
-      "version": "7.4.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@babel/types/-/types-7.4.4.tgz",
-      "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
-      "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
-        "to-fast-properties": "^2.0.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
-        }
-      }
-    },
-    "@mrmlnc/readdir-enhanced": {
-      "version": "2.2.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-      "integrity": "sha1-UkryQNGjYFJ7cwR17PoTRKpUDd4=",
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "1.1.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-      "integrity": "sha1-K1o6s/kYzKSKjHVMCBaOPwPrphs="
+      "version": "2.0.5",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos="
     },
-    "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc="
-    },
-    "@types/glob": {
-      "version": "7.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
       "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
       }
     },
-    "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0="
+    "@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha1-7nceK6Sz3Fs3KTXVSf2WF780W4w="
     },
-    "@types/node": {
-      "version": "12.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@types/node/-/node-12.0.2.tgz",
-      "integrity": "sha1-NFKiTt+f6hOLSPrUoKAopoPaHkA="
+    "@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha1-0zV0eaD9/dWQf+Z+F+CoXJBuEwE="
     },
-    "@types/unist": {
-      "version": "2.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@types/unist/-/unist-2.0.3.tgz",
-      "integrity": "sha1-nAiGeYdvN061mD8VDUeHqm+zLX4="
-    },
-    "@types/vfile": {
-      "version": "3.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@types/vfile/-/vfile-3.0.2.tgz",
-      "integrity": "sha1-GcGM0jLfEc5vpq2AJZvIbDZrCbk=",
-      "requires": {
-        "@types/node": "*",
-        "@types/unist": "*",
-        "@types/vfile-message": "*"
-      }
-    },
-    "@types/vfile-message": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/@types/vfile-message/-/vfile-message-1.0.1.tgz",
-      "integrity": "sha1-4emJXMazbEYtQkTmTm0Lbq9lNVo=",
-      "requires": {
-        "@types/node": "*",
-        "@types/unist": "*"
-      }
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-L4u0QUNNFjs1+4/9zNcTiSf/uMA="
     },
     "acorn": {
       "version": "5.6.2",
@@ -290,20 +96,20 @@
       }
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha1-kNDVRDnaWHzX6EO/twRfUL0ivfE=",
+      "version": "8.6.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ajv/-/ajv-8.6.3.tgz",
+      "integrity": "sha1-EaZlJ3Ydw+mjhF6nddLTwEFOh2Q=",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       },
       "dependencies": {
         "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
+          "version": "1.0.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI="
         }
       }
     },
@@ -331,6 +137,7 @@
       "version": "1.0.10",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -345,26 +152,6 @@
         "ast-types-flow": "0.0.7",
         "commander": "^2.11.0"
       }
-    },
-    "arr-diff": {
-      "version": "4.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-    },
-    "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
-    },
-    "arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-    },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-includes": {
       "version": "3.0.3",
@@ -381,6 +168,7 @@
       "version": "1.0.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
       "requires": {
         "array-uniq": "^1.0.1"
       }
@@ -388,12 +176,8 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-    },
-    "array-unique": {
-      "version": "0.3.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
     },
     "arrify": {
       "version": "1.0.1",
@@ -407,11 +191,6 @@
       "dev": true,
       "optional": true
     },
-    "assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -420,34 +199,9 @@
       "optional": true
     },
     "astral-regex": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k="
-    },
-    "atob": {
-      "version": "2.1.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k="
-    },
-    "autoprefixer": {
-      "version": "9.5.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/autoprefixer/-/autoprefixer-9.5.1.tgz",
-      "integrity": "sha1-JDsSZ7Z+fpR/KJGdeGtQ07sPs1c=",
-      "requires": {
-        "browserslist": "^4.5.4",
-        "caniuse-lite": "^1.0.30000957",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^7.0.14",
-        "postcss-value-parser": "^3.3.1"
-      },
-      "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30000969",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/caniuse-lite/-/caniuse-lite-1.0.30000969.tgz",
-          "integrity": "sha1-dmT1cfIHJle95wsAofwbpB8ZQqk="
-        }
-      }
+      "version": "2.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha1-SDFDxWeu7UeFdZwIZXhtx319LjE="
     },
     "axobject-query": {
       "version": "0.1.0",
@@ -508,65 +262,10 @@
         "regenerator-runtime": "^0.11.0"
       }
     },
-    "bail": {
-      "version": "1.0.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/bail/-/bail-1.0.4.tgz",
-      "integrity": "sha1-cYG2bVCKowVdP2wT8KDHIGQd3ps="
-    },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base": {
-      "version": "0.11.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/base/-/base-0.11.2.tgz",
-      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
-      "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
-      }
+      "version": "2.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/balanced-match/-/balanced-match-2.0.0.tgz",
+      "integrity": "sha1-3HD5INeNuLhYU1eVhnv0j4IGM9k="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -585,52 +284,11 @@
       }
     },
     "braces": {
-      "version": "2.3.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+      "version": "3.0.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
-      }
-    },
-    "browserslist": {
-      "version": "4.6.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/browserslist/-/browserslist-4.6.0.tgz",
-      "integrity": "sha1-UnQCjCb02TPVsTIzB8HR2lCEyf8=",
-      "requires": {
-        "caniuse-lite": "^1.0.30000967",
-        "electron-to-chromium": "^1.3.133",
-        "node-releases": "^1.1.19"
-      },
-      "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30000969",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/caniuse-lite/-/caniuse-lite-1.0.30000969.tgz",
-          "integrity": "sha1-dmT1cfIHJle95wsAofwbpB8ZQqk="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.135",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/electron-to-chromium/-/electron-to-chromium-1.3.135.tgz",
-          "integrity": "sha1-9XmblfK82N4XzeR9Yzktg6RHcEE="
-        }
+        "fill-range": "^7.0.1"
       }
     },
     "buffer-from": {
@@ -642,43 +300,8 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-    },
-    "cache-base": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
-      "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
-      }
-    },
-    "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
-    },
-    "caller-callsite": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/caller-callsite/-/caller-callsite-2.0.0.tgz",
-      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-      "requires": {
-        "callsites": "^2.0.0"
-      },
-      "dependencies": {
-        "callsites": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
-        }
-      }
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
@@ -696,18 +319,18 @@
       "dev": true
     },
     "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+      "version": "5.3.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
     },
     "camelcase-keys": {
-      "version": "4.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "version": "6.2.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha1-XnVda6UaoiPsfT1S8ld4IQ+dw8A=",
       "requires": {
-        "camelcase": "^4.1.0",
-        "map-obj": "^2.0.0",
-        "quick-lru": "^1.0.0"
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
       }
     },
     "caniuse-db": {
@@ -724,11 +347,6 @@
       "dev": true,
       "optional": true
     },
-    "ccount": {
-      "version": "1.0.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/ccount/-/ccount-1.0.4.tgz",
-      "integrity": "sha1-nPLeSUyoQGCiqNKFTt1t+wRF84Y="
-    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/chalk/-/chalk-2.4.1.tgz",
@@ -738,26 +356,6 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
-    },
-    "character-entities": {
-      "version": "1.2.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/character-entities/-/character-entities-1.2.3.tgz",
-      "integrity": "sha1-u+1KUv5++YzHE8bYDZ+qJpFtVOY="
-    },
-    "character-entities-html4": {
-      "version": "1.1.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
-      "integrity": "sha1-XObgFhjkcEisIvNPfznbXG/Wee8="
-    },
-    "character-entities-legacy": {
-      "version": "1.1.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
-      "integrity": "sha1-PHKZkdkpPaDt5t3crx8s4QCe6LQ="
-    },
-    "character-reference-invalid": {
-      "version": "1.1.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
-      "integrity": "sha1-Fkf09yZjjT6kp1DPXRl1wceRmoU="
     },
     "chardet": {
       "version": "0.4.2",
@@ -770,27 +368,6 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
-    },
-    "class-utils": {
-      "version": "0.3.6",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        }
-      }
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -808,12 +385,11 @@
       "dev": true
     },
     "clone-regexp": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/clone-regexp/-/clone-regexp-1.0.1.tgz",
-      "integrity": "sha1-BRgFzTMXM3XYIRj8CRhgbaOf1g8=",
+      "version": "2.2.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha1-fWXgCIXNh5ZAXDWnN+eoa3Qp428=",
       "requires": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
+        "is-regexp": "^2.0.0"
       }
     },
     "co": {
@@ -828,20 +404,6 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true,
       "optional": true
-    },
-    "collapse-white-space": {
-      "version": "1.0.5",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
-      "integrity": "sha1-wklbaZqx7TgNKaEJHgEGPnXbvjo="
-    },
-    "collection-visit": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-      "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
-      }
     },
     "color-convert": {
       "version": "1.9.1",
@@ -862,11 +424,6 @@
       "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8=",
       "dev": true,
       "optional": true
-    },
-    "component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -923,19 +480,6 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
-    "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "copy-descriptor": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-    },
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/core-js/-/core-js-2.5.7.tgz",
@@ -950,32 +494,26 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
+      "version": "7.0.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha1-cU11ZSLKzoZ4Z8y0R0xdAbuuXW0=",
       "requires": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
       },
       "dependencies": {
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
         "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "version": "5.2.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
           "requires": {
+            "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
           }
         }
       }
@@ -1020,13 +558,10 @@
         "postcss-value-parser": "^3.3.0"
       }
     },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "requires": {
-        "array-find-index": "^1.0.1"
-      }
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha1-N3QZGZA7hoVl4cCep0dEXNGJg+4="
     },
     "d": {
       "version": "1.0.0",
@@ -1048,18 +583,19 @@
       "version": "2.6.9",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "requires": {
         "decamelize": "^1.1.0",
@@ -1068,15 +604,10 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         }
       }
-    },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1093,43 +624,6 @@
       "requires": {
         "foreach": "^2.0.5",
         "object-keys": "^1.0.8"
-      }
-    },
-    "define-property": {
-      "version": "2.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
-      "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
-      },
-      "dependencies": {
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
       }
     },
     "del": {
@@ -1164,11 +658,11 @@
       }
     },
     "dir-glob": {
-      "version": "2.2.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/dir-glob/-/dir-glob-2.2.2.tgz",
-      "integrity": "sha1-+gnwaUFTyJGLGLoN6vrpR2n8UMQ=",
+      "version": "3.0.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
       "requires": {
-        "path-type": "^3.0.0"
+        "path-type": "^4.0.0"
       }
     },
     "doctrine": {
@@ -1178,45 +672,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "dom-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha1-HsQFnihLq+027sKUHUqXChic58A=",
-      "requires": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
-      }
-    },
-    "domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8="
-    },
-    "domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
-      "requires": {
-        "domelementtype": "1"
-      }
-    },
-    "domutils": {
-      "version": "1.7.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/domutils/-/domutils-1.7.0.tgz",
-      "integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
-      "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
-      "requires": {
-        "is-obj": "^1.0.0"
       }
     },
     "electron-to-chromium": {
@@ -1247,11 +702,6 @@
       "version": "0.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ends-with/-/ends-with-0.2.0.tgz",
       "integrity": "sha1-L52pjVelDP2kVxzkM5AAUA9Oa4o="
-    },
-    "entities": {
-      "version": "1.1.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY="
     },
     "error-ex": {
       "version": "1.3.1",
@@ -1699,7 +1149,8 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -1728,7 +1179,8 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -1742,11 +1194,11 @@
       }
     },
     "execall": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/execall/-/execall-1.0.0.tgz",
-      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+      "version": "2.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha1-FqBrX+UJnffQC+XZwG7s3tFmO0U=",
       "requires": {
-        "clone-regexp": "^1.0.0"
+        "clone-regexp": "^2.1.0"
       }
     },
     "exit-hook": {
@@ -1756,61 +1208,12 @@
       "dev": true,
       "optional": true
     },
-    "expand-brackets": {
-      "version": "2.1.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-      "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
-      }
-    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-      "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
-      }
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true,
+      "optional": true
     },
     "external-editor": {
       "version": "2.2.0",
@@ -1823,115 +1226,47 @@
         "tmp": "^0.0.33"
       }
     },
-    "extglob": {
-      "version": "2.0.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
-      "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
-      }
-    },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
     },
     "fast-glob": {
-      "version": "2.2.7",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/fast-glob/-/fast-glob-2.2.7.tgz",
-      "integrity": "sha1-aVOFfDr6R1//ku5gFdUtpwpM050=",
+      "version": "3.2.7",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha1-/Wy3otfpqnp4RhEehaGW1rL3ZqE=",
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
-      },
-      "dependencies": {
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        }
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
       }
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha1-mZD306iMxan/0fF0V0UlFwDUl+I="
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha1-YWdg+Ip1Jr38WWt8q4wYk4w2uYw=",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "fbjs": {
       "version": "0.8.16",
@@ -1978,24 +1313,11 @@
       }
     },
     "fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "version": "7.0.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "to-regex-range": "^5.0.1"
       }
     },
     "find-up": {
@@ -2021,14 +1343,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/flatted/-/flatted-2.0.0.tgz",
-      "integrity": "sha1-VRIrZTbqSWtLRIk+4mCBQdENmRY="
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+      "version": "3.2.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/flatted/-/flatted-3.2.2.tgz",
+      "integrity": "sha1-ZL/tXLaP48p4s+shStl7Y77c5WE="
     },
     "foreach": {
       "version": "2.0.5",
@@ -2036,14 +1353,6 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true,
       "optional": true
-    },
-    "fragment-cache": {
-      "version": "0.2.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-      "requires": {
-        "map-cache": "^0.2.2"
-      }
     },
     "front-matter": {
       "version": "2.1.2",
@@ -2090,8 +1399,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
-      "dev": true
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -2117,14 +1425,9 @@
       }
     },
     "get-stdin": {
-      "version": "7.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/get-stdin/-/get-stdin-7.0.0.tgz",
-      "integrity": "sha1-jV3pjxUXGhJcXlFmQ8em0OqKlvY="
-    },
-    "get-value": {
-      "version": "2.0.6",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+      "version": "8.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha1-y61qc/63X27rIrqeAfiaooqpelM="
     },
     "glob": {
       "version": "7.1.2",
@@ -2141,32 +1444,16 @@
       }
     },
     "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "version": "5.1.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
+        "is-glob": "^4.0.1"
       }
-    },
-    "glob-to-regexp": {
-      "version": "0.3.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
     },
     "global-modules": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/global-modules/-/global-modules-2.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/global-modules/-/global-modules-2.0.0.tgz",
       "integrity": "sha1-mXYFrSNF8n9RU5vqJldEISFcd4A=",
       "requires": {
         "global-prefix": "^3.0.0"
@@ -2174,7 +1461,7 @@
     },
     "global-prefix": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/global-prefix/-/global-prefix-3.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/global-prefix/-/global-prefix-3.0.0.tgz",
       "integrity": "sha1-/IX3MGTfafUEIfR/iD/luRO6m5c=",
       "requires": {
         "ini": "^1.3.5",
@@ -2185,51 +1472,37 @@
     "globals": {
       "version": "11.5.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/globals/-/globals-11.5.0.tgz",
-      "integrity": "sha1-a8hA3mdxFzsZHxPTqclNRB7pJkI="
+      "integrity": "sha1-a8hA3mdxFzsZHxPTqclNRB7pJkI=",
+      "dev": true
     },
     "globby": {
-      "version": "9.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/globby/-/globby-9.2.0.tgz",
-      "integrity": "sha1-/QKacGxwPSm90XD0tts6P3p8tj0=",
+      "version": "11.0.4",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha1-LLr/d8Lypi5x6bKBOme5ejowAaU=",
       "requires": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^1.0.2",
-        "dir-glob": "^2.2.2",
-        "fast-glob": "^2.2.6",
-        "glob": "^7.1.3",
-        "ignore": "^4.0.3",
-        "pify": "^4.0.1",
-        "slash": "^2.0.0"
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.4",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0="
         },
         "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw="
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
+          "version": "5.1.8",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha1-8VCotQo0KJsz4i9YiavU2AFvDlc="
         }
       }
     },
     "globjoin": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/globjoin/-/globjoin-0.1.4.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM="
     },
     "globule": {
@@ -2266,13 +1539,18 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha1-HG7aXBaFxjlCdm15u0Cudzzs2IM="
     },
     "has": {
       "version": "1.0.3",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -2291,57 +1569,15 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
-    "has-value": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-      "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
-      }
-    },
-    "has-values": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-      "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "hosted-git-info": {
       "version": "2.6.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
       "integrity": "sha1-IyNbKasjDFdqqw1PE/wEawsDgiI="
     },
     "html-tags": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/html-tags/-/html-tags-2.0.0.tgz",
-      "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos="
-    },
-    "htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
-      "requires": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
+      "version": "3.1.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/html-tags/-/html-tags-3.1.0.tgz",
+      "integrity": "sha1-e15vfmZen7QfMAB+2eDUHpf7IUA="
     },
     "iconv-lite": {
       "version": "0.4.23",
@@ -2359,33 +1595,25 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "version": "3.3.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
       "requires": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
       },
       "dependencies": {
-        "caller-path": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/caller-path/-/caller-path-2.0.0.tgz",
-          "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-          "requires": {
-            "caller-callsite": "^2.0.0"
-          }
-        },
         "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+          "version": "4.0.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY="
         }
       }
     },
     "import-lazy": {
-      "version": "3.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/import-lazy/-/import-lazy-3.1.0.tgz",
-      "integrity": "sha1-iRJ5ICyKIoD9vWZ029jaGh38Z8w="
+      "version": "4.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha1-6OtidIOgpD2jwD8+NVSL5csMwVM="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -2393,14 +1621,9 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-    },
-    "indexes-of": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/indexes-of/-/indexes-of-1.0.1.tgz",
-      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+      "version": "4.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE="
     },
     "inflight": {
       "version": "1.0.6",
@@ -2417,9 +1640,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
+      "version": "1.3.8",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -2460,57 +1683,16 @@
         }
       }
     },
-    "is-accessor-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "is-alphabetical": {
-      "version": "1.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
-      "integrity": "sha1-6wTMRyGaiJXYRQrORxWr/yJYofg="
-    },
-    "is-alphanumeric": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
-      "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ="
-    },
-    "is-alphanumerical": {
-      "version": "1.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
-      "integrity": "sha1-V64hw3Qnez3v4CdMZApXBLj2ZXw=",
-      "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-    },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
       "requires": {
         "builtin-modules": "^1.0.0"
       }
@@ -2522,22 +1704,12 @@
       "dev": true,
       "optional": true
     },
-    "is-data-descriptor": {
-      "version": "0.1.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+    "is-core-module": {
+      "version": "2.8.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-core-module/-/is-core-module-2.8.0.tgz",
+      "integrity": "sha1-AyEzbD0JJeSX/Zf12VyxFKXM1Ug=",
       "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
+        "has": "^1.0.3"
       }
     },
     "is-date-object": {
@@ -2547,41 +1719,9 @@
       "dev": true,
       "optional": true
     },
-    "is-decimal": {
-      "version": "1.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-decimal/-/is-decimal-1.0.3.tgz",
-      "integrity": "sha1-OBBodZudyAfYwNwL+64raOHaSLc="
-    },
-    "is-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
-      "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
-        }
-      }
-    },
-    "is-directory": {
-      "version": "0.3.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-    },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
@@ -2595,17 +1735,12 @@
       }
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+      "version": "4.0.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "requires": {
         "is-extglob": "^2.1.1"
       }
-    },
-    "is-hexadecimal": {
-      "version": "1.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
-      "integrity": "sha1-6KQmppttMUcNOjOke7glzaAlBu4="
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
@@ -2629,27 +1764,9 @@
       }
     },
     "is-number": {
-      "version": "3.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "version": "7.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -2677,16 +1794,13 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
-      "requires": {
-        "isobject": "^3.0.1"
-      }
+      "version": "5.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha1-RCf1CrNCnpAl6n1S6QQ6nvQVk0Q="
     },
     "is-promise": {
       "version": "2.1.0",
@@ -2712,9 +1826,9 @@
       }
     },
     "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+      "version": "2.1.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-regexp/-/is-regexp-2.1.0.tgz",
+      "integrity": "sha1-zXNKVoZOI7lWv058ZsOWpMCyLC0="
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -2729,11 +1843,6 @@
       "dev": true,
       "optional": true
     },
-    "is-supported-regexp-flag": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-      "integrity": "sha1-Ie4WUY0sHdPt0+mg1X5QIHrDZMo="
-    },
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/is-symbol/-/is-symbol-1.0.1.tgz",
@@ -2741,35 +1850,15 @@
       "dev": true,
       "optional": true
     },
-    "is-whitespace-character": {
-      "version": "1.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
-      "integrity": "sha1-s62VRtkW19P/p4IEvKDCa1Ylf6w="
-    },
-    "is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0="
-    },
-    "is-word-character": {
-      "version": "1.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-word-character/-/is-word-character-1.0.3.tgz",
-      "integrity": "sha1-Jk0VVBy60LqDPTmSw05rQIc7CKo="
-    },
-    "isarray": {
+    "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -2798,15 +1887,10 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q="
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk="
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -2829,14 +1913,6 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "json5": {
-      "version": "2.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/json5/-/json5-2.1.0.tgz",
-      "integrity": "sha1-56DGLEgoXGKNIKELhcibuAfDKFA=",
-      "requires": {
-        "minimist": "^1.2.0"
-      }
     },
     "jsonfile": {
       "version": "3.0.1",
@@ -2873,19 +1949,14 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+      "version": "6.0.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0="
     },
     "known-css-properties": {
-      "version": "0.13.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/known-css-properties/-/known-css-properties-0.13.0.tgz",
-      "integrity": "sha1-J1D95WbL9UKph21KzWuwJX663Sw="
-    },
-    "leven": {
-      "version": "3.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/leven/-/leven-3.1.0.tgz",
-      "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I="
+      "version": "0.23.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/known-css-properties/-/known-css-properties-0.23.0.tgz",
+      "integrity": "sha1-5kPhurKx+LopLuqVVxIcwC6YRqA="
     },
     "levn": {
       "version": "0.3.0",
@@ -2897,37 +1968,16 @@
         "type-check": "~0.3.2"
       }
     },
-    "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
       "requires": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
@@ -2936,7 +1986,8 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
         }
       }
     },
@@ -2958,6 +2009,11 @@
       "dev": true,
       "optional": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -2970,24 +2026,16 @@
       "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
       "dev": true
     },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
+    },
     "lodash.upperfirst": {
       "version": "4.3.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
       "integrity": "sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=",
       "dev": true
-    },
-    "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
-      "requires": {
-        "chalk": "^2.0.1"
-      }
-    },
-    "longest-streak": {
-      "version": "2.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/longest-streak/-/longest-streak-2.0.3.tgz",
-      "integrity": "sha1-Peej9H7hjpB03thXW1wJH10KQQU="
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -2997,15 +2045,6 @@
       "optional": true,
       "requires": {
         "js-tokens": "^3.0.0"
-      }
-    },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -3018,46 +2057,15 @@
         "yallist": "^2.1.2"
       }
     },
-    "map-cache": {
-      "version": "0.2.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
-    },
     "map-obj": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
-    },
-    "map-visit": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "requires": {
-        "object-visit": "^1.0.0"
-      }
-    },
-    "markdown-escapes": {
-      "version": "1.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
-      "integrity": "sha1-YVXhBBbvqvq2ZdRmzlmCFjdRlfU="
-    },
-    "markdown-table": {
-      "version": "1.1.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/markdown-table/-/markdown-table-1.1.3.tgz",
-      "integrity": "sha1-n8tpvP24cXv9A5jG7C2TA2743mA="
+      "version": "4.3.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha1-kwT5Buk/qucIgNoQKp8d8OqLsFo="
     },
     "mathml-tag-names": {
-      "version": "2.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
-      "integrity": "sha1-bf9myZ1V7Pc5ylPEkuYm8dEqM8w="
-    },
-    "mdast-util-compact": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/mdast-util-compact/-/mdast-util-compact-1.0.2.tgz",
-      "integrity": "sha1-wS6+Fv/8hFc9Phl2dybeIm6V9kk=",
-      "requires": {
-        "unist-util-visit": "^1.1.0"
-      }
+      "version": "2.1.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha1-TdrdZzCOeAzxakdoWHjuJ7c2oKM="
     },
     "mdn-browser-compat-data": {
       "version": "0.0.20",
@@ -3075,19 +2083,64 @@
       "integrity": "sha1-cRP8QoGRfWPOKbQ0RvcB5owlulA="
     },
     "meow": {
-      "version": "5.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/meow/-/meow-5.0.0.tgz",
-      "integrity": "sha1-38c9Y6mvxxSl43F2DrXIi5EHiqQ=",
+      "version": "9.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha1-zZUQvFysne59A8c+4fmtlZ9Oo2Q=",
       "requires": {
-        "camelcase-keys": "^4.0.0",
-        "decamelize-keys": "^1.0.0",
-        "loud-rejection": "^1.0.0",
-        "minimist-options": "^3.0.1",
-        "normalize-package-data": "^2.3.4",
-        "read-pkg-up": "^3.0.0",
-        "redent": "^2.0.0",
-        "trim-newlines": "^2.0.0",
-        "yargs-parser": "^10.0.0"
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "4.0.2",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+          "integrity": "sha1-XkJVB+7eT+qEa3Ji8IOEVsQgmWE=",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "3.0.3",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+          "integrity": "sha1-28w+LaWVCaCYNCKITNFy7v36Ul4=",
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "is-core-module": "^2.5.0",
+            "semver": "^7.3.4",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
+        }
       }
     },
     "merge": {
@@ -3098,48 +2151,17 @@
       "optional": true
     },
     "merge2": {
-      "version": "1.2.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/merge2/-/merge2-1.2.3.tgz",
-      "integrity": "sha1-fumdvWm7ZIFoklPwGEiKG5ArDtU="
+      "version": "1.4.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4="
     },
     "micromatch": {
-      "version": "4.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha1-T8sJmb+fvC/L3SEvbWKbmlbDklk=",
+      "version": "4.0.4",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=",
       "requires": {
         "braces": "^3.0.1",
-        "picomatch": "^2.0.5"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
+        "picomatch": "^2.2.3"
       }
     },
     "mimic-fn": {
@@ -3147,6 +2169,11 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
       "dev": true
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha1-pj9oFnOzBXH76LwlaGrnRu76mGk="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -3156,43 +2183,21 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
     "minimist-options": {
-      "version": "3.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/minimist-options/-/minimist-options-3.0.2.tgz",
-      "integrity": "sha1-+6TIGRM54T7PTWG+sD8HAQPz2VQ=",
+      "version": "4.1.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha1-wGVXE8U6ii69d/+iR9NCxA8BBhk=",
       "requires": {
         "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
-      }
-    },
-    "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
-      "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
       }
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -3200,14 +2205,16 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -3215,23 +2222,10 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "nanomatch": {
-      "version": "1.2.13",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
-      "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      }
+    "nanoid": {
+      "version": "3.1.30",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/nanoid/-/nanoid-3.1.30.tgz",
+      "integrity": "sha1-Y/k8xUjSoRPcXfvGO/oJ4rm2Q2I="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -3256,18 +2250,11 @@
         "is-stream": "^1.0.1"
       }
     },
-    "node-releases": {
-      "version": "1.1.19",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/node-releases/-/node-releases-1.1.19.tgz",
-      "integrity": "sha1-xJLR44H+oDULM4tkbCeGfojpGz0=",
-      "requires": {
-        "semver": "^5.3.0"
-      }
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "is-builtin-module": "^1.0.0",
@@ -3275,20 +2262,15 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
-    "normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
     },
     "normalize-selector": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/normalize-selector/-/normalize-selector-0.2.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
-    },
-    "num2fraction": {
-      "version": "1.2.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/num2fraction/-/num2fraction-1.2.2.tgz",
-      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -3303,56 +2285,12 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
-    "object-copy": {
-      "version": "0.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-      "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true,
       "optional": true
-    },
-    "object-visit": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-      "requires": {
-        "isobject": "^3.0.0"
-      }
-    },
-    "object.pick": {
-      "version": "1.3.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-      "requires": {
-        "isobject": "^3.0.1"
-      }
     },
     "once": {
       "version": "1.4.0",
@@ -3402,6 +2340,7 @@
       "version": "1.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
+      "dev": true,
       "requires": {
         "p-try": "^1.0.0"
       }
@@ -3410,6 +2349,7 @@
       "version": "2.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
       }
@@ -3417,19 +2357,22 @@
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
     },
-    "parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha1-wxvw9lO2ZhNU+Jc1WcuG3R1e31A=",
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "callsites": "^3.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M="
+        }
       }
     },
     "parse-json": {
@@ -3440,16 +2383,6 @@
       "requires": {
         "error-ex": "^1.2.0"
       }
-    },
-    "pascalcase": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
-    },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
       "version": "2.1.0",
@@ -3474,27 +2407,23 @@
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
     },
     "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
-      "requires": {
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
+      "version": "4.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs="
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw="
     },
     "picomatch": {
-      "version": "2.0.7",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/picomatch/-/picomatch-2.0.7.tgz",
-      "integrity": "sha1-UUFp2MfNC9vuzIomCeNKcWPeafY="
+      "version": "2.3.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI="
     },
     "pify": {
       "version": "2.3.0",
@@ -3531,11 +2460,6 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
       "dev": true
-    },
-    "posix-character-classes": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
       "version": "7.0.16",
@@ -3587,61 +2511,10 @@
         "postcss-resolve-nested-selector": "^0.1.1"
       }
     },
-    "postcss-html": {
-      "version": "0.36.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-html/-/postcss-html-0.36.0.tgz",
-      "integrity": "sha1-tAkT+U6qzCRT/TChMnrW7h+IsgQ=",
-      "requires": {
-        "htmlparser2": "^3.10.0"
-      }
-    },
-    "postcss-jsx": {
-      "version": "0.36.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-jsx/-/postcss-jsx-0.36.0.tgz",
-      "integrity": "sha1-t2he09BwoXXvCqSPg9kBW9dyyC0=",
-      "requires": {
-        "@babel/core": ">=7.1.0"
-      }
-    },
-    "postcss-less": {
-      "version": "3.1.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-less/-/postcss-less-3.1.4.tgz",
-      "integrity": "sha1-Np9YZCtZKO+Jj/vBpuk8lYMExa0=",
-      "requires": {
-        "postcss": "^7.0.14"
-      }
-    },
-    "postcss-markdown": {
-      "version": "0.36.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-markdown/-/postcss-markdown-0.36.0.tgz",
-      "integrity": "sha1-fyKEmuDj2xiCC3sNXngz8TpEdWA=",
-      "requires": {
-        "remark": "^10.0.1",
-        "unist-util-find-all-after": "^1.0.2"
-      }
-    },
     "postcss-media-query-parser": {
       "version": "0.2.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
-    },
-    "postcss-reporter": {
-      "version": "6.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
-      "integrity": "sha1-fAVRIAYKl8iDe05IIVZhqvt0JF8=",
-      "requires": {
-        "chalk": "^2.4.1",
-        "lodash": "^4.17.11",
-        "log-symbols": "^2.2.0",
-        "postcss": "^7.0.7"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
-        }
-      }
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
@@ -3649,50 +2522,17 @@
       "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4="
     },
     "postcss-safe-parser": {
-      "version": "4.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
-      "integrity": "sha1-h1bZ5MNv3OLHKwkbvIyhdqsfzeo=",
-      "requires": {
-        "postcss": "^7.0.0"
-      }
-    },
-    "postcss-sass": {
-      "version": "0.3.5",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-sass/-/postcss-sass-0.3.5.tgz",
-      "integrity": "sha1-bT458QGlPS76CR+VNJMRbTK+tow=",
-      "requires": {
-        "gonzales-pe": "^4.2.3",
-        "postcss": "^7.0.1"
-      },
-      "dependencies": {
-        "gonzales-pe": {
-          "version": "4.2.4",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/gonzales-pe/-/gonzales-pe-4.2.4.tgz",
-          "integrity": "sha1-NWrjajEsRv4PECbdbLU5A5+FANI=",
-          "requires": {
-            "minimist": "1.1.x"
-          }
-        },
-        "minimist": {
-          "version": "1.1.3",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/minimist/-/minimist-1.1.3.tgz",
-          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag="
-        }
-      }
-    },
-    "postcss-scss": {
-      "version": "4.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-scss/-/postcss-scss-4.0.2.tgz",
-      "integrity": "sha1-Od3MCrMvFV1asyjukTU9Z6UtU3s="
+      "version": "6.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha1-u0wpiUFxqUvFyZa5owMX70Aq2qE="
     },
     "postcss-selector-parser": {
-      "version": "3.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-      "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+      "version": "6.0.6",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+      "integrity": "sha1-LFu6gXSsL2mBq2MaQqsO5UrzMuo=",
       "requires": {
-        "dot-prop": "^4.1.1",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
       }
     },
     "postcss-sorting": {
@@ -3749,11 +2589,6 @@
         }
       }
     },
-    "postcss-syntax": {
-      "version": "0.36.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
-      "integrity": "sha1-8IV4x9lYNFdOVZOoLfv6ivrjtRw="
-    },
     "postcss-value-parser": {
       "version": "3.3.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
@@ -3807,51 +2642,131 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM="
+    },
     "quick-lru": {
-      "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/quick-lru/-/quick-lru-1.1.0.tgz",
-      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
+      "version": "4.0.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha1-W4h48ROlgheEjGSCAmxz4bpXcn8="
     },
     "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "version": "5.2.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
       "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "3.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-      "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^3.0.0"
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-parse": {
+          "version": "1.0.7",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/path-parse/-/path-parse-1.0.7.tgz",
+          "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s="
         }
       }
     },
-    "readable-stream": {
-      "version": "3.3.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/readable-stream/-/readable-stream-3.3.0.tgz",
-      "integrity": "sha1-y4ARqtAC63F78EApH+uoVpyYb7k=",
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha1-86YTV1hFlzOuK5VjgFbhhU5+9Qc=",
       "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0="
+        }
       }
     },
     "readline2": {
@@ -3876,12 +2791,12 @@
       }
     },
     "redent": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/redent/-/redent-2.0.0.tgz",
-      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "version": "3.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha1-5Ve3mYMWu1PJ8fVvpiY1LGljBZ8=",
       "requires": {
-        "indent-string": "^3.0.0",
-        "strip-indent": "^2.0.0"
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
       }
     },
     "regenerator-runtime": {
@@ -3891,88 +2806,16 @@
       "dev": true,
       "optional": true
     },
-    "regex-not": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
-      "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
-      }
-    },
     "regexpp": {
       "version": "1.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha1-DjUW3Qt5BPQT0tQZPc5GGMOmias=",
       "dev": true
     },
-    "remark": {
-      "version": "10.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/remark/-/remark-10.0.1.tgz",
-      "integrity": "sha1-MFgHbcQXgb9QXYl4wpFIX+R2Z98=",
-      "requires": {
-        "remark-parse": "^6.0.0",
-        "remark-stringify": "^6.0.0",
-        "unified": "^7.0.0"
-      }
-    },
-    "remark-parse": {
-      "version": "6.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/remark-parse/-/remark-parse-6.0.3.tgz",
-      "integrity": "sha1-yZExBSgJ2kghCEE/h7Duf1IYCjo=",
-      "requires": {
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.1.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "remark-stringify": {
-      "version": "6.0.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/remark-stringify/-/remark-stringify-6.0.4.tgz",
-      "integrity": "sha1-FqwinU0VkySQGGY8e93yiq/E4Ig=",
-      "requires": {
-        "ccount": "^1.0.0",
-        "is-alphanumeric": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "longest-streak": "^2.0.1",
-        "markdown-escapes": "^1.0.0",
-        "markdown-table": "^1.1.0",
-        "mdast-util-compact": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unherit": "^1.0.4",
-        "xtend": "^4.0.1"
-      }
-    },
-    "repeat-element": {
-      "version": "1.1.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4="
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
-    "replace-ext": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/replace-ext/-/replace-ext-1.0.0.tgz",
-      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk="
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -4003,19 +2846,15 @@
       "version": "1.7.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/resolve/-/resolve-1.7.1.tgz",
       "integrity": "sha1-qt1lY3T9KYruiVvAJrgpdBhnf9M=",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/resolve-from/-/resolve-from-5.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk="
-    },
-    "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -4027,10 +2866,10 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "ret": {
-      "version": "0.1.15",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY="
     },
     "rimraf": {
       "version": "2.6.2",
@@ -4048,6 +2887,14 @@
       "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
+      "requires": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "rx-lite": {
@@ -4068,15 +2915,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-    },
-    "safe-regex": {
-      "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-      "requires": {
-        "ret": "~0.1.10"
-      }
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -4422,27 +3262,6 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/semver/-/semver-5.5.0.tgz",
       "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs="
     },
-    "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
-      }
-    },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -4486,9 +3305,9 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slash": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q="
+      "version": "3.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ="
     },
     "slice-ansi": {
       "version": "1.0.0",
@@ -4507,129 +3326,15 @@
         }
       }
     },
-    "snapdragon": {
-      "version": "0.8.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
-      "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
-    "snapdragon-node": {
-      "version": "2.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
-      "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
-      }
-    },
-    "snapdragon-util": {
-      "version": "3.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
-      "requires": {
-        "kind-of": "^3.2.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
     },
-    "source-map-resolve": {
-      "version": "0.5.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
-      "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
-      }
-    },
-    "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha1-C7XeYxtBz72mz7qL0FqA79/SOF4="
     },
     "spdx-correct": {
       "version": "3.0.0",
@@ -4661,45 +3366,14 @@
     },
     "specificity": {
       "version": "0.4.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/specificity/-/specificity-0.4.1.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/specificity/-/specificity-0.4.1.tgz",
       "integrity": "sha1-qrXmRQEtsIuhguFRFlc40AiHsBk="
-    },
-    "split-string": {
-      "version": "3.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
-      "requires": {
-        "extend-shallow": "^3.0.0"
-      }
     },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "state-toggle": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/state-toggle/-/state-toggle-1.0.2.tgz",
-      "integrity": "sha1-dek6YZRBFrSVnWZcjbLSQ2Mdbdw="
-    },
-    "static-extend": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-      "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        }
-      }
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "string-width": {
       "version": "2.1.1",
@@ -4734,25 +3408,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/string_decoder/-/string_decoder-1.2.0.tgz",
-      "integrity": "sha1-/obnOLGVRK/nBGkkOyoe6SQOro0=",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "stringify-entities": {
-      "version": "1.3.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/stringify-entities/-/stringify-entities-1.3.2.tgz",
-      "integrity": "sha1-qYQX5Ucf0iez5F09sYYcEcr2aPc=",
-      "requires": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -4762,15 +3417,13 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-    },
     "strip-indent": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/strip-indent/-/strip-indent-2.0.0.tgz",
-      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+      "version": "3.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha1-wy4c7pQLazQyx3G8LFS8znPNMAE=",
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -4780,113 +3433,93 @@
     },
     "style-search": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/style-search/-/style-search-0.1.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
     },
     "stylelint": {
-      "version": "10.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/stylelint/-/stylelint-10.0.1.tgz",
-      "integrity": "sha1-+FzZdV6QXYJgI9Z99isycW+m37Q=",
+      "version": "14.0.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/stylelint/-/stylelint-14.0.1.tgz",
+      "integrity": "sha1-iObIvTvmHmZiJd24cYJjIfFmYfY=",
       "requires": {
-        "autoprefixer": "^9.5.1",
-        "balanced-match": "^1.0.0",
-        "chalk": "^2.4.2",
-        "cosmiconfig": "^5.2.0",
-        "debug": "^4.1.1",
-        "execall": "^1.0.0",
-        "file-entry-cache": "^5.0.1",
-        "get-stdin": "^7.0.0",
+        "balanced-match": "^2.0.0",
+        "cosmiconfig": "^7.0.1",
+        "debug": "^4.3.2",
+        "execall": "^2.0.0",
+        "fast-glob": "^3.2.7",
+        "fastest-levenshtein": "^1.0.12",
+        "file-entry-cache": "^6.0.1",
+        "get-stdin": "^8.0.0",
         "global-modules": "^2.0.0",
-        "globby": "^9.2.0",
+        "globby": "^11.0.4",
         "globjoin": "^0.1.4",
-        "html-tags": "^2.0.0",
-        "ignore": "^5.0.6",
-        "import-lazy": "^3.1.0",
+        "html-tags": "^3.1.0",
+        "ignore": "^5.1.8",
+        "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.13.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.11",
-        "log-symbols": "^2.2.0",
-        "mathml-tag-names": "^2.1.0",
-        "meow": "^5.0.0",
-        "micromatch": "^4.0.0",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.23.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^9.0.0",
+        "micromatch": "^4.0.4",
+        "normalize-path": "^3.0.0",
         "normalize-selector": "^0.2.0",
-        "pify": "^4.0.1",
-        "postcss": "^7.0.14",
-        "postcss-html": "^0.36.0",
-        "postcss-jsx": "^0.36.0",
-        "postcss-less": "^3.1.4",
-        "postcss-markdown": "^0.36.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.3.11",
         "postcss-media-query-parser": "^0.2.3",
-        "postcss-reporter": "^6.0.1",
         "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-safe-parser": "^4.0.1",
-        "postcss-sass": "^0.3.5",
-        "postcss-scss": "^2.0.0",
-        "postcss-selector-parser": "^3.1.0",
-        "postcss-syntax": "^0.36.2",
-        "postcss-value-parser": "^3.3.1",
+        "postcss-safe-parser": "^6.0.0",
+        "postcss-selector-parser": "^6.0.6",
+        "postcss-value-parser": "^4.1.0",
         "resolve-from": "^5.0.0",
-        "signal-exit": "^3.0.2",
-        "slash": "^2.0.0",
         "specificity": "^0.4.1",
-        "string-width": "^4.1.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
-        "sugarss": "^2.0.0",
         "svg-tags": "^1.0.0",
-        "table": "^5.2.3"
+        "table": "^6.7.2",
+        "v8-compile-cache": "^2.3.0",
+        "write-file-atomic": "^3.0.3"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
+          "version": "5.0.1",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "version": "4.3.2",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha1-8KScGKyHeeMdSgxgKd+3aHPHQos=",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
         },
         "file-entry-cache": {
-          "version": "5.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-          "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
+          "version": "6.0.1",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+          "integrity": "sha1-IRst2WWcsDlLBz5zI6w8kz1SICc=",
           "requires": {
-            "flat-cache": "^2.0.1"
+            "flat-cache": "^3.0.4"
           }
         },
         "flat-cache": {
-          "version": "2.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/flat-cache/-/flat-cache-2.0.1.tgz",
-          "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
+          "version": "3.0.4",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/flat-cache/-/flat-cache-3.0.4.tgz",
+          "integrity": "sha1-YbAzgwKy/p+Vfcwy/CqH8cMEixE=",
           "requires": {
-            "flatted": "^2.0.0",
-            "rimraf": "2.6.3",
-            "write": "1.0.3"
+            "flatted": "^3.1.0",
+            "rimraf": "^3.0.2"
           }
         },
         "glob": {
-          "version": "7.1.4",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+          "version": "7.2.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -4897,70 +3530,59 @@
           }
         },
         "ignore": {
-          "version": "5.1.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/ignore/-/ignore-5.1.1.tgz",
-          "integrity": "sha1-L8a49Riv9I/vZafzSO2FYyRI5KU="
+          "version": "5.1.8",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha1-8VCotQo0KJsz4i9YiavU2AFvDlc="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
-        },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+          "version": "2.1.2",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
-        },
-        "postcss-scss": {
-          "version": "2.1.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-scss/-/postcss-scss-2.1.1.tgz",
-          "integrity": "sha1-7Dp1+imlXgFrkL8yaQJsU8HSs4M=",
+        "postcss": {
+          "version": "8.3.11",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss/-/postcss-8.3.11.tgz",
+          "integrity": "sha1-w77KfqgRzV4cSj7G0udZnvH4+Fg=",
           "requires": {
-            "postcss": "^7.0.6"
+            "nanoid": "^3.1.30",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^0.6.2"
           }
         },
+        "postcss-value-parser": {
+          "version": "4.1.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+          "integrity": "sha1-RD9qIM7WSBor2k+oUypuVdeJoss="
+        },
         "rimraf": {
-          "version": "2.6.3",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+          "version": "3.0.2",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "string-width": {
-          "version": "4.1.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/string-width/-/string-width-4.1.0.tgz",
-          "integrity": "sha1-uoRtHaqXw8WWFVMIBj4HXtHJmv8=",
+          "version": "4.2.3",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^5.2.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "version": "6.0.1",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
           "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "write": {
-          "version": "1.0.3",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/write/-/write-1.0.3.tgz",
-          "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
-          "requires": {
-            "mkdirp": "^0.5.1"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -5053,14 +3675,6 @@
         "stylelint": ">=3.0.2"
       }
     },
-    "sugarss": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/sugarss/-/sugarss-2.0.0.tgz",
-      "integrity": "sha1-3dduASSyl9QL88yjHIsi7LQ7xh0=",
-      "requires": {
-        "postcss": "^7.0.2"
-      }
-    },
     "supports-color": {
       "version": "5.4.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/supports-color/-/supports-color-5.4.0.tgz",
@@ -5071,66 +3685,84 @@
     },
     "svg-tags": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/svg-tags/-/svg-tags-1.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
     },
     "table": {
-      "version": "5.3.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/table/-/table-5.3.3.tgz",
-      "integrity": "sha1-6uVgyQQ3Mxt0IA4BFIejNEK9KLQ=",
+      "version": "6.7.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/table/-/table-6.7.2.tgz",
+      "integrity": "sha1-qNObn1lmaTyosP66Jwp4ciy687A=",
       "requires": {
-        "ajv": "^6.9.1",
-        "lodash": "^4.17.11",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
+        "ajv": "^8.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+          "version": "5.0.1",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
         },
         "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY="
+          "version": "8.0.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+          "version": "3.0.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
         },
         "slice-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/slice-ansi/-/slice-ansi-2.1.0.tgz",
-          "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
+          "version": "4.0.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha1-UA6N0P1VsFgVCGJVsxla3ypF/ms=",
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "astral-regex": "^1.0.0",
-            "is-fullwidth-code-point": "^2.0.0"
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
           }
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "version": "4.2.3",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "version": "6.0.1",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -5156,73 +3788,18 @@
         "os-tmpdir": "~1.0.2"
       }
     },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-    },
-    "to-object-path": {
-      "version": "0.3.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "to-regex": {
-      "version": "3.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
-      "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
-      }
-    },
     "to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "version": "5.0.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "^7.0.0"
       }
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/trim-newlines/-/trim-newlines-2.0.0.tgz",
-      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
-    },
-    "trim-trailing-lines": {
-      "version": "1.1.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
-      "integrity": "sha1-0vHhUxYRUunwL6vGcPtAvsLqLjo="
-    },
-    "trough": {
-      "version": "1.0.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/trough/-/trough-1.0.4.tgz",
-      "integrity": "sha1-O1Kx8Tkk9GDD+/0N9ptYfby8di4="
+      "version": "3.0.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha1-Jgpdli2LdSQlsy86fbDcrNF2wUQ="
     },
     "type-check": {
       "version": "0.3.2",
@@ -5233,11 +3810,24 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha1-20vBUaSiz07r+a3V23VQjbbMhB8="
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "ua-parser-js": {
       "version": "0.7.18",
@@ -5246,109 +3836,6 @@
       "dev": true,
       "optional": true
     },
-    "unherit": {
-      "version": "1.1.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/unherit/-/unherit-1.1.2.tgz",
-      "integrity": "sha1-FPHzlyU+5OyVzsFndi5334NnhEk=",
-      "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
-      }
-    },
-    "unified": {
-      "version": "7.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/unified/-/unified-7.1.0.tgz",
-      "integrity": "sha1-UDLxwe4zZL0J2hLif91KdVPHvhM=",
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "@types/vfile": "^3.0.0",
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "trough": "^1.0.0",
-        "vfile": "^3.0.0",
-        "x-is-string": "^0.1.0"
-      }
-    },
-    "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
-      }
-    },
-    "uniq": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
-    },
-    "unist-util-find-all-after": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/unist-util-find-all-after/-/unist-util-find-all-after-1.0.2.tgz",
-      "integrity": "sha1-m+Sc+65coVZrJ1NmcKkoNr8vjW0=",
-      "requires": {
-        "unist-util-is": "^2.0.0"
-      }
-    },
-    "unist-util-is": {
-      "version": "2.1.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/unist-util-is/-/unist-util-is-2.1.2.tgz",
-      "integrity": "sha1-EZP6jyv7u4IVBjPzqNLrmhwdVds="
-    },
-    "unist-util-remove-position": {
-      "version": "1.1.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
-      "integrity": "sha1-hrXa0QTQu/vrHbX1yS81cFdcEss=",
-      "requires": {
-        "unist-util-visit": "^1.1.0"
-      }
-    },
-    "unist-util-stringify-position": {
-      "version": "1.1.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-      "integrity": "sha1-Pzf881EnncvKdICrWIm7ioMu4cY="
-    },
-    "unist-util-visit": {
-      "version": "1.4.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
-      "integrity": "sha1-HLdjZHGG3Cb14d9dtr0eSLPML7E=",
-      "requires": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "unist-util-visit-parents": {
-      "version": "2.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/unist-util-visit-parents/-/unist-util-visit-parents-2.1.0.tgz",
-      "integrity": "sha1-5FytDX5axoM2IIizKbyAq9HPxfs=",
-      "requires": {
-        "unist-util-is": "^2.1.2"
-      }
-    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/universalify/-/universalify-0.1.1.tgz",
@@ -5356,59 +3843,13 @@
       "dev": true,
       "optional": true
     },
-    "unset-value": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-      "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "2.1.0",
-              "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            }
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        }
-      }
-    },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "version": "4.4.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "urix": {
-      "version": "0.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
-    },
-    "use": {
-      "version": "3.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/use/-/use-3.1.1.tgz",
-      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8="
     },
     "user-home": {
       "version": "2.0.0",
@@ -5435,6 +3876,11 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha1-LeGWGMZtwkfc+2+ZM4A12CRaLO4="
+    },
     "validate-npm-package-license": {
       "version": "3.0.3",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
@@ -5442,37 +3888,6 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "vfile": {
-      "version": "3.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/vfile/-/vfile-3.0.1.tgz",
-      "integrity": "sha1-RzMdKr4ygkJPSku2rNIKRMQSGAM=",
-      "requires": {
-        "is-buffer": "^2.0.0",
-        "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU="
-        }
-      }
-    },
-    "vfile-location": {
-      "version": "2.0.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/vfile-location/-/vfile-location-2.0.4.tgz",
-      "integrity": "sha1-Kl5yl90Nni2kOBRk0ErMa4NNPlU="
-    },
-    "vfile-message": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/vfile-message/-/vfile-message-1.1.1.tgz",
-      "integrity": "sha1-WDOuB4od+i2W6WR4hs0ymTqzE+E=",
-      "requires": {
-        "unist-util-stringify-position": "^1.1.1"
       }
     },
     "whatwg-fetch": {
@@ -5510,15 +3925,23 @@
         "mkdirp": "^0.5.1"
       }
     },
-    "x-is-string": {
-      "version": "0.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/x-is-string/-/x-is-string-0.1.0.tgz",
-      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha1-Vr1cWlxwSBzRnFcb05q5ZaXeVug=",
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
     },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true,
+      "optional": true
     },
     "yallist": {
       "version": "2.1.2",
@@ -5526,13 +3949,15 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha1-IwHF/78StGfejaIzOkWeKeeSDks="
+    },
     "yargs-parser": {
-      "version": "10.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/yargs-parser/-/yargs-parser-10.1.0.tgz",
-      "integrity": "sha1-cgImW4n36eny5XZeD+c1qQXtuqg=",
-      "requires": {
-        "camelcase": "^4.1.0"
-      }
+      "version": "20.2.9",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha1-LrfcOwKJcY/ClfNidThFxBoMlO4="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2512,11 +2512,6 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha1-u0wpiUFxqUvFyZa5owMX70Aq2qE="
     },
-    "postcss-scss": {
-      "version": "4.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-scss/-/postcss-scss-4.0.2.tgz",
-      "integrity": "sha1-Od3MCrMvFV1asyjukTU9Z6UtU3s="
-    },
     "postcss-selector-parser": {
       "version": "6.0.6",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
@@ -2579,11 +2574,6 @@
           }
         }
       }
-    },
-    "postcss-styled": {
-      "version": "0.34.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-styled/-/postcss-styled-0.34.0.tgz",
-      "integrity": "sha1-B9R7yxNwcol4KqBYYF/Z/q+EOR0="
     },
     "postcss-value-parser": {
       "version": "3.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "dependencies": {
         "js-tokens": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/js-tokens/-/js-tokens-4.0.0.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/js-tokens/-/js-tokens-4.0.0.tgz",
           "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
         }
       }
@@ -131,15 +131,6 @@
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "requires": {
         "color-convert": "^1.9.0"
-      }
-    },
-    "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
       }
     },
     "argparse": {
@@ -276,11 +267,6 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/balanced-match/-/balanced-match-2.0.0.tgz",
       "integrity": "sha1-3HD5INeNuLhYU1eVhnv0j4IGM9k="
     },
-    "binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -376,21 +362,6 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
-    },
-    "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha1-26OXb8rbAW9m/TZQIdkWANAcHnU=",
-      "requires": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      }
     },
     "circular-json": {
       "version": "0.3.3",
@@ -619,12 +590,12 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "requires": {
         "decamelize": "^1.1.0",
@@ -633,7 +604,7 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         }
       }
@@ -1425,12 +1396,6 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
-      "optional": true
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/function-bind/-/function-bind-1.1.1.tgz",
@@ -1488,7 +1453,7 @@
     },
     "global-modules": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/global-modules/-/global-modules-2.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/global-modules/-/global-modules-2.0.0.tgz",
       "integrity": "sha1-mXYFrSNF8n9RU5vqJldEISFcd4A=",
       "requires": {
         "global-prefix": "^3.0.0"
@@ -1496,7 +1461,7 @@
     },
     "global-prefix": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/global-prefix/-/global-prefix-3.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/global-prefix/-/global-prefix-3.0.0.tgz",
       "integrity": "sha1-/IX3MGTfafUEIfR/iD/luRO6m5c=",
       "requires": {
         "ini": "^1.3.5",
@@ -1537,7 +1502,7 @@
     },
     "globjoin": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/globjoin/-/globjoin-0.1.4.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM="
     },
     "globule": {
@@ -1723,14 +1688,6 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
-    },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
@@ -1764,7 +1721,7 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
@@ -1837,7 +1794,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
@@ -2312,7 +2269,7 @@
     },
     "normalize-selector": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/normalize-selector/-/normalize-selector-0.2.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
     },
     "number-is-nan": {
@@ -2556,7 +2513,7 @@
     },
     "postcss-media-query-parser": {
       "version": "0.2.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
     },
     "postcss-resolve-nested-selector": {
@@ -2685,7 +2642,7 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
     "queue-microtask": {
@@ -2812,14 +2769,6 @@
         }
       }
     },
-    "readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
-      "requires": {
-        "picomatch": "^2.2.1"
-      }
-    },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/readline2/-/readline2-1.0.1.tgz",
@@ -2904,7 +2853,7 @@
     },
     "resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/resolve-from/-/resolve-from-5.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk="
     },
     "restore-cursor": {
@@ -2974,14 +2923,6 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
-    },
-    "sass": {
-      "version": "1.43.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/sass/-/sass-1.43.4.tgz",
-      "integrity": "sha1-aMfWobAEvvSa8NnK91DpslIQXR8=",
-      "requires": {
-        "chokidar": ">=3.0.0 <4.0.0"
-      }
     },
     "sass-lint": {
       "version": "1.12.1",
@@ -3425,7 +3366,7 @@
     },
     "specificity": {
       "version": "0.4.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/specificity/-/specificity-0.4.1.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/specificity/-/specificity-0.4.1.tgz",
       "integrity": "sha1-qrXmRQEtsIuhguFRFlc40AiHsBk="
     },
     "sprintf-js": {
@@ -3492,7 +3433,7 @@
     },
     "style-search": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/style-search/-/style-search-0.1.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
     },
     "stylelint": {
@@ -3555,7 +3496,7 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
         },
         "file-entry-cache": {
@@ -3595,7 +3536,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
         },
         "ms": {
@@ -3723,6 +3664,30 @@
         }
       }
     },
+    "stylelint-scss": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/stylelint-scss/-/stylelint-scss-4.0.0.tgz",
+      "integrity": "sha1-SQHO2SucaON2SXmaOd771fKsW80=",
+      "requires": {
+        "lodash": "^4.17.15",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.6",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
+        },
+        "postcss-value-parser": {
+          "version": "4.1.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+          "integrity": "sha1-RD9qIM7WSBor2k+oUypuVdeJoss="
+        }
+      }
+    },
     "stylelint-selector-bem-pattern": {
       "version": "2.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/stylelint-selector-bem-pattern/-/stylelint-selector-bem-pattern-2.1.0.tgz",
@@ -3744,7 +3709,7 @@
     },
     "svg-tags": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/svg-tags/-/svg-tags-1.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
     },
     "table": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,204 +12,10 @@
         "@babel/highlight": "^7.16.0"
       }
     },
-    "@babel/compat-data": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/compat-data/-/compat-data-7.16.0.tgz",
-      "integrity": "sha1-6iadf3jes6eCbDmkBI7s2lQevao="
-    },
-    "@babel/core": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/core/-/core-7.16.0.tgz",
-      "integrity": "sha1-xP9EBG9f4xBSXMnrTvUUfwxTdNQ=",
-      "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.0",
-        "@babel/helper-compilation-targets": "^7.16.0",
-        "@babel/helper-module-transforms": "^7.16.0",
-        "@babel/helpers": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.0",
-        "@babel/types": "^7.16.0",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha1-8KScGKyHeeMdSgxgKd+3aHPHQos=",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
-    "@babel/generator": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/generator/-/generator-7.16.0.tgz",
-      "integrity": "sha1-1A89HVB15i01ALzLZ/PaqKlSZbI=",
-      "requires": {
-        "@babel/types": "^7.16.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
-    "@babel/helper-compilation-targets": {
-      "version": "7.16.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
-      "integrity": "sha1-W0gM0T9oNj327E3IrI4toRNjy/A=",
-      "requires": {
-        "@babel/compat-data": "^7.16.0",
-        "@babel/helper-validator-option": "^7.14.5",
-        "browserslist": "^4.17.5",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
-        }
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
-      "integrity": "sha1-t90Hl9ALv+5PB+nE6lsOMMi7FIE=",
-      "requires": {
-        "@babel/helper-get-function-arity": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
-      "integrity": "sha1-AIjHSGspqctdlIsaHeRttm4InPo=",
-      "requires": {
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
-      "integrity": "sha1-TJAjwvHe9+KP9G/B2802o5vqqBo=",
-      "requires": {
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
-      "integrity": "sha1-KShwQO/Rl8d2Nu91GI6B2ovM1aQ=",
-      "requires": {
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-module-imports": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
-      "integrity": "sha1-kFOOYLZy7PG0SPX09UM9N+eaPsM=",
-      "requires": {
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-module-transforms": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
-      "integrity": "sha1-HIKo3UyzRXdQLr0pCWmbGUw+m7U=",
-      "requires": {
-        "@babel/helper-module-imports": "^7.16.0",
-        "@babel/helper-replace-supers": "^7.16.0",
-        "@babel/helper-simple-access": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.0",
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
-      "integrity": "sha1-zs2xRdcMVAlrFWT46fEM19GTszg=",
-      "requires": {
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
-      "integrity": "sha1-cwVejTz5vLqN21XK2T/tyGD2jxc=",
-      "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.16.0",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/traverse": "^7.16.0",
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-simple-access": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
-      "integrity": "sha1-IdaidiDjg+N1NM9sELugGab5BRc=",
-      "requires": {
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
-      "integrity": "sha1-KWcvQ2Y+k23zcKrrIr7ds7rsdDg=",
-      "requires": {
-        "@babel/types": "^7.16.0"
-      }
-    },
     "@babel/helper-validator-identifier": {
       "version": "7.15.7",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
       "integrity": "sha1-Ig35k7/pBKSmsCq08zhaXr9uI4k="
-    },
-    "@babel/helper-validator-option": {
-      "version": "7.14.5",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha1-bnKh//GNXfy4eOHmLxoCHEty1aM="
-    },
-    "@babel/helpers": {
-      "version": "7.16.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helpers/-/helpers-7.16.3.tgz",
-      "integrity": "sha1-J/xk9AuZbnB03HMSjD5cPn9VxDw=",
-      "requires": {
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.3",
-        "@babel/types": "^7.16.0"
-      }
     },
     "@babel/highlight": {
       "version": "7.16.0",
@@ -226,61 +32,6 @@
           "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/js-tokens/-/js-tokens-4.0.0.tgz",
           "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
         }
-      }
-    },
-    "@babel/parser": {
-      "version": "7.16.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/parser/-/parser-7.16.3.tgz",
-      "integrity": "sha1-Jxuvy4EQgJBaEZIi7bwXkJyCJh0="
-    },
-    "@babel/template": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/template/-/template-7.16.0.tgz",
-      "integrity": "sha1-0Wo16/TNdOICCDNW+rId2JNj3dY=",
-      "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.16.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/traverse/-/traverse-7.16.3.tgz",
-      "integrity": "sha1-9j6Kk4zBt4D2bZ7TxU9TLKLRR4c=",
-      "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.0",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-hoist-variables": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/parser": "^7.16.3",
-        "@babel/types": "^7.16.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha1-8KScGKyHeeMdSgxgKd+3aHPHQos=",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        }
-      }
-    },
-    "@babel/types": {
-      "version": "7.16.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha1-2zsxOAT5aq3Qt3bEgj4SetZyibo=",
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "@nodelib/fs.scandir": {
@@ -304,14 +55,6 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
-      }
-    },
-    "@stylelint/postcss-css-in-js": {
-      "version": "0.37.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz",
-      "integrity": "sha1-flqErRgfQjSiSAgDQipHuHSa89I=",
-      "requires": {
-        "@babel/core": ">=7.9.0"
       }
     },
     "@types/minimist": {
@@ -548,30 +291,6 @@
         "fill-range": "^7.0.1"
       }
     },
-    "browserslist": {
-      "version": "4.17.6",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/browserslist/-/browserslist-4.17.6.tgz",
-      "integrity": "sha1-x2vjPneGtJf2bK0lpzdWyLk4mF0=",
-      "requires": {
-        "caniuse-lite": "^1.0.30001274",
-        "electron-to-chromium": "^1.3.886",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.1",
-        "picocolors": "^1.0.0"
-      },
-      "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001279",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-          "integrity": "sha1-6waBjaSB71CWo7N2D0PlOC7WsM4="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.894",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/electron-to-chromium/-/electron-to-chromium-1.3.894.tgz",
-          "integrity": "sha1-VFVOy0DUDdrHJBxKQoh+hhgAFdg="
-        }
-      }
-    },
     "buffer-from": {
       "version": "1.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/buffer-from/-/buffer-from-1.1.0.tgz",
@@ -760,14 +479,6 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
-    },
-    "convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha1-8zc8MtIbTXgN2ABFFGhPt5HKQ2k=",
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
     },
     "core-js": {
       "version": "2.5.7",
@@ -1099,11 +810,6 @@
         "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
       }
-    },
-    "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1718,11 +1424,6 @@
         "is-property": "^1.0.0"
       }
     },
-    "gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA="
-    },
     "get-stdin": {
       "version": "8.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/get-stdin/-/get-stdin-8.0.0.tgz",
@@ -1771,7 +1472,8 @@
     "globals": {
       "version": "11.5.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/globals/-/globals-11.5.0.tgz",
-      "integrity": "sha1-a8hA3mdxFzsZHxPTqclNRB7pJkI="
+      "integrity": "sha1-a8hA3mdxFzsZHxPTqclNRB7pJkI=",
+      "dev": true
     },
     "globby": {
       "version": "11.0.4",
@@ -2185,11 +1887,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q="
-    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -2216,14 +1913,6 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "json5": {
-      "version": "2.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha1-Lf7+cgxrpSXZ69kJlQ8FFTFsiaM=",
-      "requires": {
-        "minimist": "^1.2.5"
-      }
     },
     "jsonfile": {
       "version": "3.0.1",
@@ -2494,11 +2183,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
-    },
     "minimist-options": {
       "version": "4.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/minimist-options/-/minimist-options-4.1.0.tgz",
@@ -2565,11 +2249,6 @@
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
       }
-    },
-    "node-releases": {
-      "version": "2.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/node-releases/-/node-releases-2.0.1.tgz",
-      "integrity": "sha1-PR05XyBPHy8ppUNYuftnh2WtL8U="
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -2901,11 +2580,6 @@
         }
       }
     },
-    "postcss-syntax": {
-      "version": "0.36.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
-      "integrity": "sha1-8IV4x9lYNFdOVZOoLfv6ivrjtRw="
-    },
     "postcss-value-parser": {
       "version": "3.3.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
@@ -3232,7 +2906,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -4103,11 +3778,6 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "dependencies": {
         "js-tokens": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/js-tokens/-/js-tokens-4.0.0.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/js-tokens/-/js-tokens-4.0.0.tgz",
           "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
         }
       }
@@ -131,6 +131,15 @@
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "requires": {
         "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "argparse": {
@@ -267,6 +276,11 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/balanced-match/-/balanced-match-2.0.0.tgz",
       "integrity": "sha1-3HD5INeNuLhYU1eVhnv0j4IGM9k="
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -362,6 +376,21 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
+    },
+    "chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha1-26OXb8rbAW9m/TZQIdkWANAcHnU=",
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
     },
     "circular-json": {
       "version": "0.3.3",
@@ -590,12 +619,12 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "requires": {
         "decamelize": "^1.1.0",
@@ -604,7 +633,7 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         }
       }
@@ -1396,6 +1425,12 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/function-bind/-/function-bind-1.1.1.tgz",
@@ -1453,7 +1488,7 @@
     },
     "global-modules": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/global-modules/-/global-modules-2.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/global-modules/-/global-modules-2.0.0.tgz",
       "integrity": "sha1-mXYFrSNF8n9RU5vqJldEISFcd4A=",
       "requires": {
         "global-prefix": "^3.0.0"
@@ -1461,7 +1496,7 @@
     },
     "global-prefix": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/global-prefix/-/global-prefix-3.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/global-prefix/-/global-prefix-3.0.0.tgz",
       "integrity": "sha1-/IX3MGTfafUEIfR/iD/luRO6m5c=",
       "requires": {
         "ini": "^1.3.5",
@@ -1502,7 +1537,7 @@
     },
     "globjoin": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/globjoin/-/globjoin-0.1.4.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM="
     },
     "globule": {
@@ -1688,6 +1723,14 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
@@ -1721,7 +1764,7 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
@@ -1794,7 +1837,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
@@ -2269,7 +2312,7 @@
     },
     "normalize-selector": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/normalize-selector/-/normalize-selector-0.2.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
     },
     "number-is-nan": {
@@ -2513,7 +2556,7 @@
     },
     "postcss-media-query-parser": {
       "version": "0.2.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
     },
     "postcss-resolve-nested-selector": {
@@ -2642,7 +2685,7 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
     "queue-microtask": {
@@ -2769,6 +2812,14 @@
         }
       }
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/readline2/-/readline2-1.0.1.tgz",
@@ -2853,7 +2904,7 @@
     },
     "resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/resolve-from/-/resolve-from-5.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk="
     },
     "restore-cursor": {
@@ -2923,6 +2974,14 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
+    },
+    "sass": {
+      "version": "1.43.4",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/sass/-/sass-1.43.4.tgz",
+      "integrity": "sha1-aMfWobAEvvSa8NnK91DpslIQXR8=",
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0"
+      }
     },
     "sass-lint": {
       "version": "1.12.1",
@@ -3366,7 +3425,7 @@
     },
     "specificity": {
       "version": "0.4.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/specificity/-/specificity-0.4.1.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/specificity/-/specificity-0.4.1.tgz",
       "integrity": "sha1-qrXmRQEtsIuhguFRFlc40AiHsBk="
     },
     "sprintf-js": {
@@ -3433,7 +3492,7 @@
     },
     "style-search": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/style-search/-/style-search-0.1.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
     },
     "stylelint": {
@@ -3496,7 +3555,7 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
         },
         "file-entry-cache": {
@@ -3536,7 +3595,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
         },
         "ms": {
@@ -3685,7 +3744,7 @@
     },
     "svg-tags": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/svg-tags/-/svg-tags-1.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
     },
     "table": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2580,6 +2580,11 @@
         }
       }
     },
+    "postcss-styled": {
+      "version": "0.34.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-styled/-/postcss-styled-0.34.0.tgz",
+      "integrity": "sha1-B9R7yxNwcol4KqBYYF/Z/q+EOR0="
+    },
     "postcss-value-parser": {
       "version": "3.3.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -991,20 +991,33 @@
         "which": "^1.2.9"
       }
     },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
+    },
+    "css-shorthand-properties": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz",
+      "integrity": "sha1-HICOY1U8KD8ony3Vb87o8zN72TU="
+    },
     "css-tree": {
-      "version": "1.0.0-alpha.29",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
-      "integrity": "sha1-P6nU7zFCy9HDAedmTB81K9gvWjk=",
+      "version": "1.1.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha1-60hw+2/XcHMn7JXC/yqwm16NuR0=",
       "requires": {
-        "mdn-data": "~1.1.0",
-        "source-map": "^0.5.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      }
+    },
+    "css-values": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/css-values/-/css-values-0.1.0.tgz",
+      "integrity": "sha1-Eot84QPU3AJ6gUpdWZXFR4HXtMY=",
+      "requires": {
+        "css-color-names": "0.0.4",
+        "ends-with": "^0.2.0",
+        "postcss-value-parser": "^3.3.0"
       }
     },
     "currently-unhandled": {
@@ -1229,6 +1242,11 @@
       "requires": {
         "iconv-lite": "~0.4.13"
       }
+    },
+    "ends-with": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ends-with/-/ends-with-0.2.0.tgz",
+      "integrity": "sha1-L52pjVelDP2kVxzkM5AAUA9Oa4o="
     },
     "entities": {
       "version": "1.1.2",
@@ -3052,9 +3070,9 @@
       }
     },
     "mdn-data": {
-      "version": "1.1.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/mdn-data/-/mdn-data-1.1.3.tgz",
-      "integrity": "sha1-0JKc33PbMrCv1tOrjvPaKym292s="
+      "version": "2.0.14",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha1-cRP8QoGRfWPOKbQ0RvcB5owlulA="
     },
     "meow": {
       "version": "5.0.0",
@@ -3663,12 +3681,9 @@
       }
     },
     "postcss-scss": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-scss/-/postcss-scss-2.0.0.tgz",
-      "integrity": "sha1-JIsKKK936nsysQEaug9zi9on3qE=",
-      "requires": {
-        "postcss": "^7.0.0"
-      }
+      "version": "4.0.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-scss/-/postcss-scss-4.0.2.tgz",
+      "integrity": "sha1-Od3MCrMvFV1asyjukTU9Z6UtU3s="
     },
     "postcss-selector-parser": {
       "version": "3.1.1",
@@ -4457,6 +4472,14 @@
       "dev": true,
       "optional": true
     },
+    "shortcss": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/shortcss/-/shortcss-0.1.3.tgz",
+      "integrity": "sha1-7ip5BNgLf1UCyYQI9KLzE/qt+0g=",
+      "requires": {
+        "css-shorthand-properties": "^1.0.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -4898,6 +4921,14 @@
           "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/pify/-/pify-4.0.1.tgz",
           "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
         },
+        "postcss-scss": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-scss/-/postcss-scss-2.1.1.tgz",
+          "integrity": "sha1-7Dp1+imlXgFrkL8yaQJsU8HSs4M=",
+          "requires": {
+            "postcss": "^7.0.6"
+          }
+        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/rimraf/-/rimraf-2.6.3.tgz",
@@ -4935,65 +4966,26 @@
       }
     },
     "stylelint-csstree-validator": {
-      "version": "1.3.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/stylelint-csstree-validator/-/stylelint-csstree-validator-1.3.0.tgz",
-      "integrity": "sha1-WCk8aIpQoCwSKJcgLWC8s3+ub/E=",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/stylelint-csstree-validator/-/stylelint-csstree-validator-1.9.0.tgz",
+      "integrity": "sha1-n3lx2Hv1JfVOIENDKfpeJ+5OlJE=",
       "requires": {
-        "css-tree": "1.0.0-alpha.29"
+        "css-tree": "^1.0.0"
       }
     },
     "stylelint-declaration-block-no-ignored-properties": {
-      "version": "2.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/stylelint-declaration-block-no-ignored-properties/-/stylelint-declaration-block-no-ignored-properties-2.1.0.tgz",
-      "integrity": "sha1-NIGtR3g0QWNxZbCxXw8BzE+iEhE=",
-      "requires": {
-        "postcss": "^7.0.14"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "postcss": {
-          "version": "7.0.16",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss/-/postcss-7.0.16.tgz",
-          "integrity": "sha1-SPZPG0tVjLi1LIiYdyQ1mssBDaI=",
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
+      "version": "2.4.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/stylelint-declaration-block-no-ignored-properties/-/stylelint-declaration-block-no-ignored-properties-2.4.0.tgz",
+      "integrity": "sha1-dn8FqqFTUzVPKA1uMkXHa/9REBA="
     },
     "stylelint-declaration-strict-value": {
-      "version": "1.1.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/stylelint-declaration-strict-value/-/stylelint-declaration-strict-value-1.1.3.tgz",
-      "integrity": "sha1-Wvr0QBnAjdynaXXb1m8fT3eruw0="
+      "version": "1.7.12",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/stylelint-declaration-strict-value/-/stylelint-declaration-strict-value-1.7.12.tgz",
+      "integrity": "sha1-pP9dbPyVXJHy2+G3W9NdqZ3TXQI=",
+      "requires": {
+        "css-values": "^0.1.0",
+        "shortcss": "^0.1.3"
+      }
     },
     "stylelint-order": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "dependencies": {
         "js-tokens": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/js-tokens/-/js-tokens-4.0.0.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/js-tokens/-/js-tokens-4.0.0.tgz",
           "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
         }
       }
@@ -590,12 +590,12 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "requires": {
         "decamelize": "^1.1.0",
@@ -604,7 +604,7 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         }
       }
@@ -1453,7 +1453,7 @@
     },
     "global-modules": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/global-modules/-/global-modules-2.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/global-modules/-/global-modules-2.0.0.tgz",
       "integrity": "sha1-mXYFrSNF8n9RU5vqJldEISFcd4A=",
       "requires": {
         "global-prefix": "^3.0.0"
@@ -1461,7 +1461,7 @@
     },
     "global-prefix": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/global-prefix/-/global-prefix-3.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/global-prefix/-/global-prefix-3.0.0.tgz",
       "integrity": "sha1-/IX3MGTfafUEIfR/iD/luRO6m5c=",
       "requires": {
         "ini": "^1.3.5",
@@ -1502,7 +1502,7 @@
     },
     "globjoin": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/globjoin/-/globjoin-0.1.4.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM="
     },
     "globule": {
@@ -1721,7 +1721,7 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
@@ -1794,7 +1794,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
@@ -2269,7 +2269,7 @@
     },
     "normalize-selector": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/normalize-selector/-/normalize-selector-0.2.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
     },
     "number-is-nan": {
@@ -2462,43 +2462,13 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.16",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss/-/postcss-7.0.16.tgz",
-      "integrity": "sha1-SPZPG0tVjLi1LIiYdyQ1mssBDaI=",
+      "version": "8.3.11",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss/-/postcss-8.3.11.tgz",
+      "integrity": "sha1-w77KfqgRzV4cSj7G0udZnvH4+Fg=",
       "requires": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "nanoid": "^3.1.30",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^0.6.2"
       }
     },
     "postcss-bem-linter": {
@@ -2509,11 +2479,27 @@
         "minimatch": "^3.0.3",
         "postcss": "^7.0.14",
         "postcss-resolve-nested-selector": "^0.1.1"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha1-VwZw95NkaFHRuhNZlpYqutWHhZ8="
+        },
+        "postcss": {
+          "version": "7.0.39",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss/-/postcss-7.0.39.tgz",
+          "integrity": "sha1-liQ3XZZWMOLh8sAqk1yCpZy0gwk=",
+          "requires": {
+            "picocolors": "^0.2.1",
+            "source-map": "^0.6.1"
+          }
+        }
       }
     },
     "postcss-media-query-parser": {
       "version": "0.2.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
     },
     "postcss-resolve-nested-selector": {
@@ -2525,6 +2511,11 @@
       "version": "6.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha1-u0wpiUFxqUvFyZa5owMX70Aq2qE="
+    },
+    "postcss-scss": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-scss/-/postcss-scss-4.0.2.tgz",
+      "integrity": "sha1-Od3MCrMvFV1asyjukTU9Z6UtU3s="
     },
     "postcss-selector-parser": {
       "version": "6.0.6",
@@ -2642,7 +2633,7 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
     "queue-microtask": {
@@ -2853,7 +2844,7 @@
     },
     "resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/resolve-from/-/resolve-from-5.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk="
     },
     "restore-cursor": {
@@ -3366,7 +3357,7 @@
     },
     "specificity": {
       "version": "0.4.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/specificity/-/specificity-0.4.1.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/specificity/-/specificity-0.4.1.tgz",
       "integrity": "sha1-qrXmRQEtsIuhguFRFlc40AiHsBk="
     },
     "sprintf-js": {
@@ -3433,7 +3424,7 @@
     },
     "style-search": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/style-search/-/style-search-0.1.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
     },
     "stylelint": {
@@ -3496,7 +3487,7 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
         },
         "file-entry-cache": {
@@ -3536,7 +3527,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
         },
         "ms": {
@@ -3709,7 +3700,7 @@
     },
     "svg-tags": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/svg-tags/-/svg-tags-1.0.0.tgz",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
     },
     "table": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2896,6 +2896,11 @@
         }
       }
     },
+    "postcss-syntax": {
+      "version": "0.36.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
+      "integrity": "sha1-8IV4x9lYNFdOVZOoLfv6ivrjtRw="
+    },
     "postcss-value-parser": {
       "version": "3.3.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,204 @@
         "@babel/highlight": "^7.16.0"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/compat-data/-/compat-data-7.16.0.tgz",
+      "integrity": "sha1-6iadf3jes6eCbDmkBI7s2lQevao="
+    },
+    "@babel/core": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/core/-/core-7.16.0.tgz",
+      "integrity": "sha1-xP9EBG9f4xBSXMnrTvUUfwxTdNQ=",
+      "requires": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-compilation-targets": "^7.16.0",
+        "@babel/helper-module-transforms": "^7.16.0",
+        "@babel/helpers": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha1-8KScGKyHeeMdSgxgKd+3aHPHQos=",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha1-1A89HVB15i01ALzLZ/PaqKlSZbI=",
+      "requires": {
+        "@babel/types": "^7.16.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.16.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
+      "integrity": "sha1-W0gM0T9oNj327E3IrI4toRNjy/A=",
+      "requires": {
+        "@babel/compat-data": "^7.16.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.17.5",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha1-t90Hl9ALv+5PB+nE6lsOMMi7FIE=",
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha1-AIjHSGspqctdlIsaHeRttm4InPo=",
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha1-TJAjwvHe9+KP9G/B2802o5vqqBo=",
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
+      "integrity": "sha1-KShwQO/Rl8d2Nu91GI6B2ovM1aQ=",
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+      "integrity": "sha1-kFOOYLZy7PG0SPX09UM9N+eaPsM=",
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
+      "integrity": "sha1-HIKo3UyzRXdQLr0pCWmbGUw+m7U=",
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-replace-supers": "^7.16.0",
+        "@babel/helper-simple-access": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
+      "integrity": "sha1-zs2xRdcMVAlrFWT46fEM19GTszg=",
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
+      "integrity": "sha1-cwVejTz5vLqN21XK2T/tyGD2jxc=",
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.16.0",
+        "@babel/helper-optimise-call-expression": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
+      "integrity": "sha1-IdaidiDjg+N1NM9sELugGab5BRc=",
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha1-KWcvQ2Y+k23zcKrrIr7ds7rsdDg=",
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
     "@babel/helper-validator-identifier": {
       "version": "7.15.7",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
       "integrity": "sha1-Ig35k7/pBKSmsCq08zhaXr9uI4k="
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha1-bnKh//GNXfy4eOHmLxoCHEty1aM="
+    },
+    "@babel/helpers": {
+      "version": "7.16.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/helpers/-/helpers-7.16.3.tgz",
+      "integrity": "sha1-J/xk9AuZbnB03HMSjD5cPn9VxDw=",
+      "requires": {
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.3",
+        "@babel/types": "^7.16.0"
+      }
     },
     "@babel/highlight": {
       "version": "7.16.0",
@@ -32,6 +226,61 @@
           "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/js-tokens/-/js-tokens-4.0.0.tgz",
           "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
         }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.16.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/parser/-/parser-7.16.3.tgz",
+      "integrity": "sha1-Jxuvy4EQgJBaEZIi7bwXkJyCJh0="
+    },
+    "@babel/template": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha1-0Wo16/TNdOICCDNW+rId2JNj3dY=",
+      "requires": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.16.3",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha1-9j6Kk4zBt4D2bZ7TxU9TLKLRR4c=",
+      "requires": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha1-8KScGKyHeeMdSgxgKd+3aHPHQos=",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.16.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha1-2zsxOAT5aq3Qt3bEgj4SetZyibo=",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@nodelib/fs.scandir": {
@@ -55,6 +304,14 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@stylelint/postcss-css-in-js": {
+      "version": "0.37.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz",
+      "integrity": "sha1-flqErRgfQjSiSAgDQipHuHSa89I=",
+      "requires": {
+        "@babel/core": ">=7.9.0"
       }
     },
     "@types/minimist": {
@@ -291,6 +548,30 @@
         "fill-range": "^7.0.1"
       }
     },
+    "browserslist": {
+      "version": "4.17.6",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/browserslist/-/browserslist-4.17.6.tgz",
+      "integrity": "sha1-x2vjPneGtJf2bK0lpzdWyLk4mF0=",
+      "requires": {
+        "caniuse-lite": "^1.0.30001274",
+        "electron-to-chromium": "^1.3.886",
+        "escalade": "^3.1.1",
+        "node-releases": "^2.0.1",
+        "picocolors": "^1.0.0"
+      },
+      "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30001279",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
+          "integrity": "sha1-6waBjaSB71CWo7N2D0PlOC7WsM4="
+        },
+        "electron-to-chromium": {
+          "version": "1.3.894",
+          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/electron-to-chromium/-/electron-to-chromium-1.3.894.tgz",
+          "integrity": "sha1-VFVOy0DUDdrHJBxKQoh+hhgAFdg="
+        }
+      }
+    },
     "buffer-from": {
       "version": "1.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/buffer-from/-/buffer-from-1.1.0.tgz",
@@ -479,6 +760,14 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha1-8zc8MtIbTXgN2ABFFGhPt5HKQ2k=",
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "core-js": {
       "version": "2.5.7",
@@ -810,6 +1099,11 @@
         "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1424,6 +1718,11 @@
         "is-property": "^1.0.0"
       }
     },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA="
+    },
     "get-stdin": {
       "version": "8.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/get-stdin/-/get-stdin-8.0.0.tgz",
@@ -1472,8 +1771,7 @@
     "globals": {
       "version": "11.5.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/globals/-/globals-11.5.0.tgz",
-      "integrity": "sha1-a8hA3mdxFzsZHxPTqclNRB7pJkI=",
-      "dev": true
+      "integrity": "sha1-a8hA3mdxFzsZHxPTqclNRB7pJkI="
     },
     "globby": {
       "version": "11.0.4",
@@ -1887,6 +2185,11 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q="
+    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -1913,6 +2216,14 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json5": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha1-Lf7+cgxrpSXZ69kJlQ8FFTFsiaM=",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
     },
     "jsonfile": {
       "version": "3.0.1",
@@ -2183,6 +2494,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
+    },
     "minimist-options": {
       "version": "4.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/minimist-options/-/minimist-options-4.1.0.tgz",
@@ -2249,6 +2565,11 @@
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
       }
+    },
+    "node-releases": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha1-PR05XyBPHy8ppUNYuftnh2WtL8U="
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -2511,11 +2832,6 @@
       "version": "6.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha1-u0wpiUFxqUvFyZa5owMX70Aq2qE="
-    },
-    "postcss-scss": {
-      "version": "4.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-scss/-/postcss-scss-4.0.2.tgz",
-      "integrity": "sha1-Od3MCrMvFV1asyjukTU9Z6UtU3s="
     },
     "postcss-selector-parser": {
       "version": "6.0.6",
@@ -2906,8 +3222,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -3655,30 +3970,6 @@
         }
       }
     },
-    "stylelint-scss": {
-      "version": "4.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/stylelint-scss/-/stylelint-scss-4.0.0.tgz",
-      "integrity": "sha1-SQHO2SucaON2SXmaOd771fKsW80=",
-      "requires": {
-        "lodash": "^4.17.15",
-        "postcss-media-query-parser": "^0.2.3",
-        "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-selector-parser": "^6.0.6",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
-        },
-        "postcss-value-parser": {
-          "version": "4.1.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-          "integrity": "sha1-RD9qIM7WSBor2k+oUypuVdeJoss="
-        }
-      }
-    },
     "stylelint-selector-bem-pattern": {
       "version": "2.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-all/stylelint-selector-bem-pattern/-/stylelint-selector-bem-pattern-2.1.0.tgz",
@@ -3802,6 +4093,11 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-streamotion-cache/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@stylelint/postcss-css-in-js": "^0.37.2"
   },
   "dependencies": {
-    "postcss": "^8.1.0",
+    "postcss": "^8.3.3",
     "postcss-scss": "^4.0.2",
     "postcss-syntax": "^0.36.2",
     "stylelint": "^14.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "postcss": "^8.1.0",
-    "postcss-syntax": "^0.36.2",
     "@stylelint/postcss-css-in-js": "^0.37.2",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fs-default-project-config": "^6.1.2"
   },
   "peerDependencies": {
-    "postcss": "^8.3.11",
+    "postcss-scss": "^4.0.2",
     "stylelint": "^14.0.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,18 +22,14 @@
     "fs-default-project-config": "^6.1.2"
   },
   "peerDependencies": {
-    "postcss-scss": "^4.0.2",
     "stylelint": "^14.0.1"
   },
   "dependencies": {
-    "postcss": "^8.3.11",
-    "postcss-scss": "^4.0.2",
-    "stylelint": "^14.0.1",
+    "@stylelint/postcss-css-in-js": "^0.37.2",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",
     "stylelint-declaration-strict-value": "^1.7.12",
     "stylelint-order": "^3.0.0",
-    "stylelint-scss": "^4.0.0",
     "stylelint-selector-bem-pattern": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "stylelint": "^14.0.1"
   },
   "dependencies": {
-    "sass": "^1.43.4",
     "stylelint": "^14.0.1",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",
     "stylelint-declaration-strict-value": "^1.7.12",
     "stylelint-order": "^3.0.0",
+    "stylelint-scss": "^4.0.0",
     "stylelint-selector-bem-pattern": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "fs-default-project-config": "^6.1.2"
   },
   "peerDependencies": {
-    "stylelint": "^14.0.1",
-    "postcss": "^8.3.11",
-    "postcss-scss": "^4.0.2"
+    "stylelint": "^14.0.1"
   },
   "dependencies": {
+    "postcss": "^8.3.11",
+    "postcss-scss": "^4.0.2",
     "stylelint": "^14.0.1",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
     "stylelint": "^14.0.1"
   },
   "dependencies": {
-    "stylelint-csstree-validator": "^1.3.0",
-    "stylelint-declaration-block-no-ignored-properties": "^2.1.0",
-    "stylelint-declaration-strict-value": "^1.1.3",
+    "postcss-scss": "^4.0.2",
+    "stylelint-csstree-validator": "^1.9.0",
+    "stylelint-declaration-block-no-ignored-properties": "^2.4.0",
+    "stylelint-declaration-strict-value": "^1.7.12",
     "stylelint-order": "^3.0.0",
     "stylelint-selector-bem-pattern": "^2.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "stylelint": "^14.0.1"
   },
   "dependencies": {
-    "postcss-scss": "^4.0.2",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",
     "stylelint-declaration-strict-value": "^1.7.12",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "stylelint": "^14.0.1"
   },
   "dependencies": {
+    "sass": "^1.43.4",
     "stylelint": "^14.0.1",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,10 @@
     "fs-default-project-config": "^6.1.2"
   },
   "peerDependencies": {
-    "postcss": "^8.3.11",
     "stylelint": "^14.0.1",
     "@stylelint/postcss-css-in-js": "^0.37.2"
   },
   "dependencies": {
-    "postcss": "^8.3.11",
     "@stylelint/postcss-css-in-js": "^0.37.2",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fs-default-project-config": "^6.1.2"
   },
   "peerDependencies": {
-    "stylelint": "^10.0.1"
+    "stylelint": "^13.13.1"
   },
   "dependencies": {
     "stylelint-csstree-validator": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -21,16 +21,10 @@
     "eslint-plugin-import": "^2.8.0",
     "fs-default-project-config": "^6.1.2"
   },
-  "peerDependencies": {
-    "stylelint": "^14.0.1",
-    "@stylelint/postcss-css-in-js": "^0.37.2"
-  },
   "dependencies": {
     "postcss": "^8.3.3",
     "postcss-scss": "^4.0.2",
-    "postcss-syntax": "^0.36.2",
     "stylelint": "^14.0.1",
-    "@stylelint/postcss-css-in-js": "^0.37.2",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",
     "stylelint-declaration-strict-value": "^1.7.12",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "postcss": "^8.3.11",
+    "postcss-styled": "^0.34.0",
     "stylelint": "^14.0.1",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "stylelint": "^14.0.1"
   },
   "dependencies": {
+    "postcss": "^8.3.11",
+    "postcss-scss": "^4.0.2",
     "stylelint": "^14.0.1",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "@stylelint/postcss-css-in-js": "^0.37.2"
   },
   "dependencies": {
+    "postcss": "^8.1.0",
+    "postcss-syntax": "^0.36.2",
     "@stylelint/postcss-css-in-js": "^0.37.2",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fs-default-project-config": "^6.1.2"
   },
   "peerDependencies": {
-    "stylelint": "^13.13.1"
+    "stylelint": "^14.0.1"
   },
   "dependencies": {
     "stylelint-csstree-validator": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "fs-default-project-config": "^6.1.2"
   },
   "peerDependencies": {
+    "postcss": "^8.3.11",
     "stylelint": "^14.0.1"
   },
   "dependencies": {
     "postcss": "^8.3.11",
     "postcss-scss": "^4.0.2",
-    "postcss-styled": "^0.34.0",
     "stylelint": "^14.0.1",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "fs-default-project-config": "^6.1.2"
   },
   "peerDependencies": {
-    "stylelint": "^14.0.1"
+    "stylelint": "^14.0.1",
+    "@stylelint/postcss-css-in-js": "^0.37.2"
   },
   "dependencies": {
     "@stylelint/postcss-css-in-js": "^0.37.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "postcss": "^8.3.11",
     "postcss-scss": "^4.0.2",
+    "postcss-styled": "^0.34.0",
     "stylelint": "^14.0.1",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "stylelint": "^14.0.1"
   },
   "dependencies": {
+    "stylelint": "^14.0.1",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",
     "stylelint-declaration-strict-value": "^1.7.12",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "fs-default-project-config": "^6.1.2"
   },
   "peerDependencies": {
+    "postcss": "^8.3.11",
     "stylelint": "^14.0.1",
     "@stylelint/postcss-css-in-js": "^0.37.2"
   },
   "dependencies": {
+    "postcss": "^8.3.11",
     "@stylelint/postcss-css-in-js": "^0.37.2",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "postcss": "^8.1.0",
     "postcss-syntax": "^0.36.2",
+    "stylelint": "^14.0.1",
     "@stylelint/postcss-css-in-js": "^0.37.2",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "fs-default-project-config": "^6.1.2"
   },
   "peerDependencies": {
-    "stylelint": "^14.0.1"
+    "stylelint": "^14.0.1",
+    "postcss": "^8.3.11",
+    "postcss-scss": "^4.0.2"
   },
   "dependencies": {
-    "postcss": "^8.3.11",
-    "postcss-scss": "^4.0.2",
     "stylelint": "^14.0.1",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "postcss": "^8.1.0",
+    "postcss-syntax": "^0.36.2",
     "@stylelint/postcss-css-in-js": "^0.37.2",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
   },
   "dependencies": {
     "postcss": "^8.3.11",
-    "postcss-scss": "^4.0.2",
-    "postcss-styled": "^0.34.0",
     "stylelint": "^14.0.1",
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "postcss": "^8.1.0",
+    "postcss-scss": "^4.0.2",
     "postcss-syntax": "^0.36.2",
     "stylelint": "^14.0.1",
     "@stylelint/postcss-css-in-js": "^0.37.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "postcss": "^8.3.11",
+    "postcss-scss": "^4.0.2",
     "postcss-styled": "^0.34.0",
     "stylelint": "^14.0.1",
     "stylelint-csstree-validator": "^1.9.0",

--- a/rules/limit-language-features.js
+++ b/rules/limit-language-features.js
@@ -95,6 +95,6 @@ module.exports = {
     // General / Sheet
     'linebreaks': null, // Specify unix or windows linebreaks.
     'max-nesting-depth': [2, {ignore: ['blockless-at-rules', 'pseudo-classes']}], // Limit the depth of nesting.
-    'alpha-value-notation': number, // Specify percentage or number notation for alpha-values.
+    'alpha-value-notation': "number", // Specify percentage or number notation for alpha-values.
     'hue-degree-notation': "angle", // Specify number or angle notation for degree hues.
 }

--- a/rules/limit-language-features.js
+++ b/rules/limit-language-features.js
@@ -6,11 +6,11 @@ module.exports = {
     'color-no-hex': null, // Disallow hex colors.
 
     // Function
-    'function-blacklist': null, // Specify a blacklist of disallowed functions.
+    'function-disallowed-list': null, // Specify a list of disallowed functions
     'function-url-no-scheme-relative': true, // Disallow scheme-relative urls.
-    'function-url-scheme-blacklist': ["ftp", "/^http/"], // Specify a blacklist of disallowed url schemes.
-    'function-url-scheme-whitelist': null, // Specify a whitelist of allowed url schemes.
-    'function-whitelist': null, // Specify a whitelist of allowed functions.
+    'function-url-scheme-disallowed-list': ["ftp", "/^http/"], // Specify a list of disallowed URL schemes.
+    'function-url-scheme-allowed-list': null, // Specify a list of allowed URL schemes.
+    'function-allowed-list': null, // Specify a list of allowed functions.
 
     // animations/keyframes
     'keyframes-name-pattern': null, // Specify a pattern for keyframe names.
@@ -19,11 +19,11 @@ module.exports = {
     'number-max-precision': 2, // Limit the number of decimal places allowed in numbers.
 
     // Time
-    'time-min-milliseconds': 100, // Specify the minimum number of milliseconds for time values.
+    'time-min-milliseconds': [100, {ignore: ["delay"]}], // Specify the minimum number of milliseconds for time values.
 
     // Unit
-    'unit-blacklist': null, // Specify a blacklist of disallowed units.
-    'unit-whitelist': null, // Specify a whitelist of allowed units.
+    'unit-disallowed-list': null, // Specify a list of disallowed units.
+    'unit-allowed-list': null, // Specify a list of allowed units.
 
     // Value
     'value-no-vendor-prefix': true, // Disallow vendor prefixes for values.
@@ -32,30 +32,31 @@ module.exports = {
     'custom-property-pattern': "fs-.+", // Specify a pattern for custom properties.
 
     // Property
-    'property-blacklist': null, // Specify a blacklist of disallowed properties.
+    'property-disallowed-list': null, // Specify a list of disallowed properties.
     'property-no-vendor-prefix': true, // Disallow vendor prefixes for properties.
-    'property-whitelist': null, // Specify a whitelist of allowed properties.
+    'property-allowed-list': null, // Specify a list of allowed properties.
 
     // Declaration
     'declaration-no-important': true, // Disallow !important within declarations.
-    'declaration-property-unit-blacklist': null, // Specify a blacklist of disallowed property and unit pairs within declarations.
-    'declaration-property-unit-whitelist': null, // Specify a whitelist of allowed property and unit pairs within declarations.
-    'declaration-property-value-blacklist': null, // Specify a blacklist of disallowed property and value pairs within declarations.
-    'declaration-property-value-whitelist': null, // Specify a whitelist of allowed property and value pairs within declarations.
+    'declaration-property-unit-disallowed-list': null, // Specify a list of disallowed property and unit pairs within declarations.
+    'declaration-property-unit-allowed-list': null, // Specify a list of allowed property and unit pairs within declarations.
+    'declaration-property-value-disallowed-list': null, // Specify a list of disallowed property and value pairs within declarations.
+    'declaration-property-value-allowed-list': null, // Specify a list of allowed property and value pairs within declarations.
 
     // Declaration block
     'declaration-block-single-line-max-declarations': null, // Limit the number of declaration within single line declaration blocks.
 
     // Selector
-    'selector-attribute-operator-blacklist': null, // Specify a blacklist of disallowed attribute operators.
-    'selector-attribute-operator-whitelist': null, // Specify a whitelist of allowed attribute operators.
+    'selector-attribute-operator-disallowed-list': null, // Specify a list of disallowed attribute operators.
+    'selector-attribute-operator-allowed-list': null, // Specify a list of allowed attribute operators.
+    'selector-attribute-name-disallowed-list': null, // Specify a list of disallowed attribute names.
     'selector-class-pattern': null, // Specify a pattern for class selectors.
-    'selector-combinator-blacklist': null, // Specify a blacklist of disallowed combinators
-    'selector-combinator-whitelist': null, // Specify a whitelist of allowed combinators
+    'selector-combinator-disallowed-list': null, // Specify a list of disallowed combinators.
+    'selector-combinator-allowed-list': null, // Specify a list of allowed combinators.
     'selector-id-pattern': null, // Specify a pattern for id selectors.
     'selector-max-attribute': 2, // Limit the number of attribute selectors in a selector.
     'selector-max-class': null, // Limit the number of classes in a selector. (covered by selector-max-specificity)
-    'selector-max-combinators': 2, // Limit the number of combinators in a selector.
+    'selector-max-combinators': 3, // Limit the number of combinators in a selector.
     'selector-max-compound-selectors': 3, // Limit the number of compound selectors in a selector.
     'selector-max-empty-lines': 0, // Limit the number of adjacent empty lines within selectors.
     'selector-max-id': null, // Limit the number of id selectors in a selector. (covered by selector-max-specificity)
@@ -66,28 +67,29 @@ module.exports = {
     'selector-nested-pattern': null, // Specify a pattern for the selectors of rules nested within rules.
     'selector-no-qualifying-type': [true, { ignore: ["attribute"] }], // Disallow qualifying a selector by type.
     'selector-no-vendor-prefix': true, // Disallow vendor prefixes for selectors.
-    'selector-pseudo-class-blacklist': null, // Specify a blacklist of disallowed pseudo-class selectors.
-    'selector-pseudo-class-whitelist': null, // Specify a whitelist of allowed pseudo-class selectors.
-    'selector-pseudo-element-blacklist': null, // Specify a blacklist of disallowed pseudo-element selectors
-    'selector-pseudo-element-whitelist': null, // Specify a whitelist of allowed pseudo-element selectors
+    'selector-pseudo-class-disallowed-list': null, // Specify a list of disallowed pseudo-class selectors.
+    'selector-pseudo-class-allowed-list': null, // Specify a list of allowed pseudo-class selectors.
+    'selector-pseudo-element-disallowed-list': null, // Specify a list of disallowed pseudo-element selectors.
+    'selector-pseudo-element-allowed-list': null, // Specify a list of allowed pseudo-element selectors.
 
     // Media feature
-    'media-feature-name-blacklist': null, // Specify a blacklist of disallowed media feature names.
+    'media-feature-name-disallowed-list': null, // Specify a list of disallowed media feature names.
     'media-feature-name-no-vendor-prefix': true, // Disallow vendor prefixes for media feature names.
-    'media-feature-name-value-whitelist': null, // Specify a whitelist of allowed media feature name and value pairs.
-    'media-feature-name-whitelist': null, // Specify a whitelist of allowed media feature names.
+    'media-feature-name-value-allowed-list': null, // Specify a list of allowed media feature name and value pairs.
+    'media-feature-name-allowed-list': null, // Specify a list of allowed media feature names.
 
     // Custom media
     'custom-media-pattern': "fs-.+", // Specify a pattern for custom media query names.
 
     // At-rule
-    'at-rule-blacklist': null, // Specify a blacklist of disallowed at-rules.
+    'at-rule-disallowed-list': null, // Specify a list of disallowed at-rules.
     'at-rule-no-vendor-prefix': true, // Disallow vendor prefixes for at-rules.
-    'at-rule-property-requirelist': {}, // Specify a requirelist of properties for an at-rule.
-    'at-rule-whitelist': null, // Specify a whitelist of allowed at-rules.
+    'at-rule-property-required-list': {}, // Specify a list of required properties for an at-rule.
+    'at-rule-allowed-list': null, // Specify a list of allowed at-rules.
 
     // Comment
-    'comment-word-blacklist': ["/^TODO/", { "severity": "warning" }], // Specify a blacklist of disallowed words within comments.
+    'comment-word-disallowed-list': ["/^TODO/", { "severity": "warning" }], // Specify a list of disallowed words within comments.
+    'comment-pattern': '^[a-z].*$', // Specify a pattern for comments.
 
     // General / Sheet
     'linebreaks': null, // Specify unix or windows linebreaks.

--- a/rules/limit-language-features.js
+++ b/rules/limit-language-features.js
@@ -95,6 +95,6 @@ module.exports = {
     // General / Sheet
     'linebreaks': null, // Specify unix or windows linebreaks.
     'max-nesting-depth': [2, {ignore: ['blockless-at-rules', 'pseudo-classes']}], // Limit the depth of nesting.
-    'alpha-value-notation': null, // Specify percentage or number notation for alpha-values.
+    'alpha-value-notation': number, // Specify percentage or number notation for alpha-values.
     'hue-degree-notation': "angle", // Specify number or angle notation for degree hues.
 }

--- a/rules/limit-language-features.js
+++ b/rules/limit-language-features.js
@@ -4,6 +4,7 @@ module.exports = {
     // Color
     'color-named': "never", // Require (where possible) or disallow named colors.
     'color-no-hex': null, // Disallow hex colors.
+    'color-function-notation': "legacy", // Specify modern or legacy notation for applicable color-functions.
 
     // Function
     'function-disallowed-list': null, // Specify a list of disallowed functions
@@ -56,7 +57,7 @@ module.exports = {
     'selector-id-pattern': null, // Specify a pattern for id selectors.
     'selector-max-attribute': 2, // Limit the number of attribute selectors in a selector.
     'selector-max-class': null, // Limit the number of classes in a selector. (covered by selector-max-specificity)
-    'selector-max-combinators': 3, // Limit the number of combinators in a selector.
+    'selector-max-combinators': 2, // Limit the number of combinators in a selector.
     'selector-max-compound-selectors': 3, // Limit the number of compound selectors in a selector.
     'selector-max-empty-lines': 0, // Limit the number of adjacent empty lines within selectors.
     'selector-max-id': null, // Limit the number of id selectors in a selector. (covered by selector-max-specificity)
@@ -89,9 +90,11 @@ module.exports = {
 
     // Comment
     'comment-word-disallowed-list': ["/^TODO/", { "severity": "warning" }], // Specify a list of disallowed words within comments.
-    'comment-pattern': '^[a-z].*$', // Specify a pattern for comments.
+    'comment-pattern': null, // Specify a pattern for comments.
 
     // General / Sheet
     'linebreaks': null, // Specify unix or windows linebreaks.
     'max-nesting-depth': [2, {ignore: ['blockless-at-rules', 'pseudo-classes']}], // Limit the depth of nesting.
+    'alpha-value-notation': null, // Specify percentage or number notation for alpha-values.
+    'hue-degree-notation': "angle", // Specify number or angle notation for degree hues.
 }

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -6,14 +6,9 @@ module.exports = {
 
     // Font family
     'font-family-no-duplicate-names': true, // Disallow duplicate font family names.
-    'font-family-no-missing-generic-family-keyword': [true, {ignoreFontFamilies: [
-        "icons",
-        "FontAwesome",
-        // "var(--font)", // the rule should ignore values that contain variables
-    ]}], // Disallow missing generic families in lists of font family names
+    'font-family-no-missing-generic-family-keyword': true, // Disallow missing generic families in lists of font family names
 
     // Function
-    'function-calc-no-invalid': true, // Disallow an invalid expression within calc functions.
     'function-calc-no-unspaced-operator': true, // Disallow an unspaced operator within calc functions.
     'function-linear-gradient-no-nonstandard-direction': true, // Disallow direction values in linear-gradient() calls that are not valid according to the standard syntax.
 

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -39,7 +39,7 @@ module.exports = {
     // Selector
     'selector-pseudo-class-no-unknown': true, // Disallow unknown pseudo-class selectors.
     'selector-pseudo-element-no-unknown': true, // Disallow unknown pseudo-element selectors.
-    'selector-type-no-unknown': [true, {ignoreTypes: ["/^-styled-mixin/"]}], // Disallow unknown type selectors.
+    'selector-type-no-unknown': true, // Disallow unknown type selectors.
 
     // Media feature
     'media-feature-name-no-unknown': true, // Disallow unknown media feature names.

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -6,7 +6,11 @@ module.exports = {
 
     // Font family
     'font-family-no-duplicate-names': true, // Disallow duplicate font family names.
-    'font-family-no-missing-generic-family-keyword': true, // Disallow missing generic families in lists of font family names
+    'font-family-no-missing-generic-family-keyword': [true, {ignoreFontFamilies: [
+        "icons",
+        "FontAwesome",
+        // "var(--font)", // the rule should ignore values that contain variables
+    ]}], // Disallow missing generic families in lists of font family names
 
     // Function
     'function-calc-no-invalid': true, // Disallow an invalid expression within calc functions.
@@ -23,7 +27,7 @@ module.exports = {
     'shorthand-property-no-redundant-values': true, // Disallow redundant values in shorthand properties.
 
     // Property
-    'property-no-unknown': true, // Disallow unknown properties.
+    'property-no-unknown': [true, {ignoreAtRules: ["supports"]}], // Disallow unknown properties.
 
     // Keyframe declaration
     'keyframe-declaration-no-important': true, // Disallow !important within keyframe declarations.
@@ -32,6 +36,7 @@ module.exports = {
     'declaration-block-no-duplicate-properties': true, // Disallow duplicate properties within declaration blocks.
     'declaration-block-no-redundant-longhand-properties': true, // Disallow longhand properties that can be combined into one shorthand property.
     'declaration-block-no-shorthand-property-overrides': true, // Disallow shorthand properties that override related longhand properties within declaration blocks.
+    'declaration-block-no-duplicate-custom-properties': true, // disallow duplicate custom properties within declaration blocks
 
     // Block
     'block-no-empty': true, // Disallow empty blocks.
@@ -51,11 +56,12 @@ module.exports = {
     'comment-no-empty': true, // Disallow empty comments.
 
     // General / Sheet
-    'no-descending-specificity': true, // Disallow selectors of lower specificity from coming after overriding selectors of higher specificity.
+    'no-descending-specificity': [true, {ignore: ["selectors-within-list"]}], // Disallow selectors of lower specificity from coming after overriding selectors of higher specificity.
     'no-duplicate-at-import-rules': true, // Disallow duplicate @import rules within a stylesheet (not that styled-components is affected)
     'no-duplicate-selectors': true, // Disallow duplicate selectors.
     'no-empty-source': true, // Disallow empty sources.
     'no-extra-semicolons': true, // Disallow extra semicolons.
     'no-invalid-double-slash-comments': true, // Disallow double-slash comments (//...) which are not supported by CSS.
-    'no-unknown-animations': null // Disallow unknown animations.
+    'no-unknown-animations': null, // Disallow unknown animations.
+    'unicode-bom': 'never', // Require or disallow the Unicode Byte Order Mark
 }

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -39,7 +39,7 @@ module.exports = {
     // Selector
     'selector-pseudo-class-no-unknown': true, // Disallow unknown pseudo-class selectors.
     'selector-pseudo-element-no-unknown': true, // Disallow unknown pseudo-element selectors.
-    'selector-type-no-unknown': true, // Disallow unknown type selectors.
+    'selector-type-no-unknown': [true, {ignoreTypes: ["/^-styled-mixin/"]}], // Disallow unknown type selectors.
 
     // Media feature
     'media-feature-name-no-unknown': true, // Disallow unknown media feature names.

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -100,7 +100,7 @@ module.exports = {
     'selector-disallowed-list': null, // specify a list of disallowed selectors
 
     // Rule
-    'rule-empty-line-before': ['always', {except: ['first-nested'], ignore: ['after-comment']}], // Require or disallow an empty line before rules (Autofixable).
+    'rule-empty-line-before': ['always', {except: ['first-nested', 'inside-block-and-after-rule'], ignore: ['after-comment']}], // Require or disallow an empty line before rules (Autofixable).
 
     // Media feature
     'media-feature-colon-space-after': "always", // Require a single space or disallow whitespace after the colon in media features.

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -65,7 +65,7 @@ module.exports = {
     'declaration-block-semicolon-newline-before': null, // Require a newline or disallow whitespace before the semicolons of declaration blocks.
     'declaration-block-semicolon-space-after': null, // Require a single space or disallow whitespace after the semicolons of declaration blocks.
     'declaration-block-semicolon-space-before': "never", // Require a single space or disallow whitespace before the semicolons of declaration blocks.
-    'declaration-block-trailing-semicolon': ["always", {except: 'single-declaration'}], // Require or disallow a trailing semicolon within declaration blocks.
+    'declaration-block-trailing-semicolon': "always", // Require or disallow a trailing semicolon within declaration blocks.
 
     // Block
     'block-closing-brace-empty-line-before': "never", // Require or disallow an empty line before the closing brace of blocks.
@@ -136,5 +136,5 @@ module.exports = {
     'no-eol-whitespace': true, // Disallow end-of-line whitespace.
     'no-missing-end-of-source-newline': true, // Disallow missing end-of-source newlines (Autofixable).
     'no-irregular-whitespace': true, // Disallow irregular whitespaces.
-    'no-invalid-position-at-import-rule': true, // Disallow invalid position @import rules within styleshit
+    'no-invalid-position-at-import-rule': true, // Disallow invalid position @import rules within stylesheet
 }

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -65,7 +65,7 @@ module.exports = {
     'declaration-block-semicolon-newline-before': null, // Require a newline or disallow whitespace before the semicolons of declaration blocks.
     'declaration-block-semicolon-space-after': null, // Require a single space or disallow whitespace after the semicolons of declaration blocks.
     'declaration-block-semicolon-space-before': "never", // Require a single space or disallow whitespace before the semicolons of declaration blocks.
-    'declaration-block-trailing-semicolon': "always", // Require or disallow a trailing semicolon within declaration blocks.
+    'declaration-block-trailing-semicolon': ["always", {except: 'single-declaration'}], // Require or disallow a trailing semicolon within declaration blocks.
 
     // Block
     'block-closing-brace-empty-line-before': "never", // Require or disallow an empty line before the closing brace of blocks.
@@ -76,7 +76,7 @@ module.exports = {
     'block-opening-brace-newline-after': "always-multi-line", // Require a newline after the opening brace of blocks.
     'block-opening-brace-newline-before': null, // Require a newline or disallow whitespace before the opening brace of blocks.
     'block-opening-brace-space-after': "always-single-line", // Require a single space or disallow whitespace after the opening brace of blocks.
-    'block-opening-brace-space-before': "always", // Require a single space or disallow whitespace before the opening brace of blocks.
+    'block-opening-brace-space-before': ["always", {ignoreSelectors: ['[0-9+%']}], // Require a single space or disallow whitespace before the opening brace of blocks.
 
     // Selector
     'selector-attribute-brackets-space-inside': "never", // Require a single space or disallow whitespace on the inside of the brackets within attribute selectors.
@@ -85,7 +85,7 @@ module.exports = {
     'selector-attribute-quotes': "always", // Require or disallow quotes for attribute values.
     'selector-combinator-space-after': "always", // Require a single space or disallow whitespace after the combinators of selectors.
     'selector-combinator-space-before': "always", // Require a single space or disallow whitespace before the combinators of selectors.
-    'selector-descendant-combinator-no-non-space': true, // Disallow non-space characters for descendant combinators of selectors.
+    'selector-descendant-combinator-no-non-space': true, // Disallow non-space characters for descendant combinators of selectors. This rule currently ignores selectors containing comments.
     'selector-pseudo-class-case': "lower", // Specify lowercase or uppercase for pseudo-class selectors.
     'selector-pseudo-class-parentheses-space-inside': "never", // Require a single space or disallow whitespace on the inside of the parentheses within pseudo-class selectors.
     'selector-pseudo-element-case': "lower", // Specify lowercase or uppercase for pseudo-element selectors.
@@ -97,6 +97,7 @@ module.exports = {
     'selector-list-comma-newline-before': null, // Require a newline or disallow whitespace before the commas of selector lists.
     'selector-list-comma-space-after': null, // Require a single space or disallow whitespace after the commas of selector lists.
     'selector-list-comma-space-before': null, // Require a single space or disallow whitespace before the commas of selector lists.
+    'selector-disallowed-list': null, // specify a list of disallowed selectors
 
     // Rule
     'rule-empty-line-before': ['always', {except: ['first-nested'], ignore: ['after-comment']}], // Require or disallow an empty line before rules (Autofixable).
@@ -134,4 +135,6 @@ module.exports = {
     'no-empty-first-line': true, // Disallow empty first lines.
     'no-eol-whitespace': true, // Disallow end-of-line whitespace.
     'no-missing-end-of-source-newline': true, // Disallow missing end-of-source newlines (Autofixable).
+    'no-irregular-whitespace': true, // Disallow irregular whitespaces.
+    'no-invalid-position-at-import-rule': true, // Disallow invalid position @import rules within styleshit
 }

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -100,7 +100,7 @@ module.exports = {
     'selector-disallowed-list': null, // specify a list of disallowed selectors
 
     // Rule
-    'rule-empty-line-before': ['always', {except: ['first-nested', 'inside-block-and-after-rule'], ignore: ['after-comment']}], // Require or disallow an empty line before rules (Autofixable).
+    'rule-empty-line-before': ['always', {except: ['first-nested'], ignore: ['after-comment']}], // Require or disallow an empty line before rules (Autofixable).
 
     // Media feature
     'media-feature-colon-space-after': "always", // Require a single space or disallow whitespace after the colon in media features.


### PR DESCRIPTION
This PR aims to update the stylelint from v10.0.1 to v13.13.1

Rules that were newly added to stylelint but I was not really sure we need them:

- `hue-degree-notation` (added in 13.5.0)
- `color-function-notation` (added in 13.5.0)
- `alpha-value-notation` (added in 13.5.0)
**UPDATE**: the above have now been added.

Also there are some new config keys available now (as of 13.10.0) such as:

- `ignoreDisables`
- `reportNeedlessDisables`
- `reportDescriptionlessDisables`
- `reportInvalidScopeDisables`


that the stylelint team was so excited about (:D), so [this](https://github.com/stylelint/stylelint/pull/5126#pullrequestreview-584293731) is a reference to their excitement! Ummm, I don't really understand the need for or the importance of these 4 config keys so if anyone could explain it to me that would be awesome. Also the issue link is[ here](https://stylelint.io/CHANGELOG#13100).
**UPDATE**: the above have now been added.


With `14.0.0` there has been a secondary option that can be used for any rule, exactly like `severity` and this new one is called `disableFix`; It was introduced because sometimes we need to find error which should not be automatically fixed, or it was automatically fixed by mistake, instead, we want to fix it manually. 

Example:

```
a {
        color: red; // two indentations before color
   }
```
And your rule being:
`indentation: [2, {disableFix: true}]`

Then stylelint would error on this one because it has not been auto fixed.The example on indentation though does not make much sense! But are there any rules among the rules that we have that you guys would think we want this to be enforced?

Also with 14.0.0, they have removed the Node.js 10 support, I assume we use 14 so I assume this won’t be an issue but just highlighting this here in case I am missing something.


Other than the above I will elaborate on the changes that have been added in this PR right where they have been added. 

[Sample usage of this upgrade in Infinity](https://bitbucket.foxsports.com.au/projects/MAR/repos/infinity/pull-requests/234/overview)

[Sample usage of this upgrade in Ionic]( https://bitbucket.foxsports.com.au/projects/MAR/repos/ionic/pull-requests/358/overview)

NOTE: aiming to go ahead with merging and versioning this one after the upgrade in Flash Widget (In Progress...)